### PR TITLE
Replace table for trailing zeros with direct calculation.

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -705,14 +705,6 @@ inline auto digits2(size_t value) noexcept -> const char* {
   return &data[value * 2];
 }
 
-// The idea of branchless trailing zero removal is by Alexander Bolz.
-const char num_trailing_zeros[] =
-    "\2\0\0\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0"
-    "\1\0\0\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0"
-    "\1\0\0\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0"
-    "\1\0\0\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0"
-    "\1\0\0\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0";
-
 struct div_mod_result {
   uint32_t div;
   uint32_t mod;
@@ -730,13 +722,22 @@ inline auto divmod100(uint32_t value) noexcept -> div_mod_result {
   return {div, value - div * 100};
 }
 
+// Number of trailing zeros in the four-digit string pointed to by p.
+// Assumes little-endian.
+inline auto num_trailing_zeros(const char *p) noexcept {
+#ifdef _MSC_VER
+  return _lzcnt_u32(*(uint32_t*)p - 0x30303030) / 8;
+#else
+  return __builtin_clz(*(uint32_t*)p - 0x30303030) / 8;
+#endif
+}
+
 // Writes 4 digits and removes trailing zeros.
 auto write4digits(char* buffer, uint32_t value) noexcept -> char* {
   auto [aa, bb] = divmod100<4>(value);
   memcpy(buffer + 0, digits2(aa), 2);
   memcpy(buffer + 2, digits2(bb), 2);
-  return buffer + 4 - num_trailing_zeros[bb] -
-         (bb == 0) * num_trailing_zeros[aa];
+  return buffer + 4 - num_trailing_zeros(buffer);
 }
 
 // Writes a significand consisting of 16 or 17 decimal digits and removes
@@ -760,7 +761,7 @@ auto write_significand(char* buffer, uint64_t value) noexcept -> char* {
 
   if (ffgghhii == 0) {
     if (ddee != 0) return write4digits(buffer, ddee);
-    return buffer - num_trailing_zeros[cc] - (cc == 0) * num_trailing_zeros[bb];
+    return buffer - num_trailing_zeros(buffer);
   }
   auto [dd, ee] = divmod100<4>(ddee);
   uint32_t ffgg = ffgghhii / 10'000;
@@ -771,8 +772,7 @@ auto write_significand(char* buffer, uint64_t value) noexcept -> char* {
   memcpy(buffer + 4, digits2(ff), 2);
   memcpy(buffer + 6, digits2(gg), 2);
   if (hhii != 0) return write4digits(buffer + 8, hhii);
-  return buffer + 8 - num_trailing_zeros[gg] -
-         (gg == 0) * num_trailing_zeros[ff];
+  return buffer + 8 - num_trailing_zeros(buffer + 4);
 }
 
 // Writes the decimal FP number dec_sig * 10**dec_exp to buffer.


### PR DESCRIPTION
żmij reads the number of trailing zeros from a table in order to adjust the end of buffer. Determining the number of trailing zeros in the four-byte blocks written can be done in three or four assembly instructions and doing it this way performs equally well in my tests with MSVC. Tested by copying zmij.cc into dtoa-benchmark and running it. On my laptop the current trunk and this version both fluctuate between 25ns and 26ns per conversion.

A big-endian architecture (if it exists) would have to search for the non-zero bits in the opposite direction.

In my builds the dtoa-benchmark executable shrinks by 512 bytes, from 235008 bytes to 234496 bytes, i.e. 512 bytes less. The .obj itself gets larger, but I haven't studied the reason. 

It's been fun following your adventures into schubfach, which i can pronounce (and type!) with much more confidence than żmij.

Edit: as usual I got little-endian and big-endian mixed up, and fixed the comment mentioning it with a forced push.