### PR TITLE
Write digits in groups of eight

### DIFF
--- a/zmij-test.cc
+++ b/zmij-test.cc
@@ -10,6 +10,19 @@ auto dtoa(double value) -> std::string {
   return buffer;
 }
 
+TEST(zmij_test, utilities) {
+  EXPECT_EQ(lzcntl(0), 64);
+  EXPECT_EQ(lzcntl(1), 63);
+  EXPECT_EQ(lzcntl(~0ull), 0);
+
+  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303030ull), 0);
+  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303031ull), 1);
+  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303039ull), 1);
+  EXPECT_EQ(count_trailing_nonzeros(0x30393030'39303030ull), 7);
+  EXPECT_EQ(count_trailing_nonzeros(0x31303030'30303030ull), 8);
+  EXPECT_EQ(count_trailing_nonzeros(0x39303030'30303030ull), 8);
+}
+
 TEST(zmij_test, umul192_upper64_modified) {
   auto pow10 = pow10_significands[0];
   EXPECT_EQ(


### PR DESCRIPTION
Writes the digits in blocks of eight instead of two and then adjust for the triailing zeros only once. They are identified by bit-counting of the eight-digit block.

This is an extension of my previous pull request. Unlike the previous, this benchmarks on par on linux and avoids all issues due to bit counting builtins not being clearly specified. This is achieved by relying on the compiler to find the right instruction. I explored `std::countl_zero` but it seemed to pessimize performance, at least on Windows.

On Windows it generally benchmarks minimally faster, on Linux it benchmarks on par, and maybe faster when `-mlzcnt` is given which allows the more efficient LZCNT instruction to be used (unlike BSR it needs no special handling of the zero case).

It removes two branches compared to the main branch, but adds two unconditional multiplications in the case of short decimal representations (which are unlikely, because a zero digit is less probable than a non-zero digit).

Here is a "lucky" benchmark run with `kTrial == 20` on Linux, generally the relative performance fluctuates a little. `zmjj_new` is this version
<img width="1615" height="1202" alt="image" src="https://github.com/user-attachments/assets/0c0b9f18-4cda-4b61-a6b3-d0e9ffd60303" />

This version clocks in at <s>322</s>320 lines of assembly <s>https://godbolt.org/z/5YTzY3zEb</s>https://godbolt.org/z/f3vv1Y3f7 (updated for second patch).
The current main branch compiles to 339 lines of assembly, including an additional 100byte buffer https://godbolt.org/z/exr3E581E
