### PR TITLE
Use BCD coding to evaluate eight significand digits in parallel

### DIFF
--- a/test/zmij-test.cc
+++ b/test/zmij-test.cc
@@ -17,12 +17,12 @@ TEST(zmij_test, utilities) {
   EXPECT_EQ(countl_zero(1), 63);
   EXPECT_EQ(countl_zero(~0ull), 0);
 
-  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303030ull), 0);
-  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303031ull), 1);
-  EXPECT_EQ(count_trailing_nonzeros(0x30303030'30303039ull), 1);
-  EXPECT_EQ(count_trailing_nonzeros(0x30393030'39303030ull), 7);
-  EXPECT_EQ(count_trailing_nonzeros(0x31303030'30303030ull), 8);
-  EXPECT_EQ(count_trailing_nonzeros(0x39303030'30303030ull), 8);
+  EXPECT_EQ(count_trailing_nonzeros(0x00000000'00000000ull), 0);
+  EXPECT_EQ(count_trailing_nonzeros(0x00000000'00000001ull), 1);
+  EXPECT_EQ(count_trailing_nonzeros(0x00000000'00000009ull), 1);
+  EXPECT_EQ(count_trailing_nonzeros(0x00090000'09000000ull), 7);
+  EXPECT_EQ(count_trailing_nonzeros(0x01000000'00000000ull), 8);
+  EXPECT_EQ(count_trailing_nonzeros(0x09000000'00000000ull), 8);
 }
 
 TEST(zmij_test, umul192_upper64_inexact_to_odd) {


### PR DESCRIPTION
… instead of table lookups. This similar to what https://mastodon.social/@pkhuong@discuss.systems described, but for eight digits (and I of course avoided adding 0x30s before counting bits, as Paul also mentioned). The bcd sequence doesn't use [xjb714](https://github.com/xjb714)'s tricks that he described in https://github.com/vitaut/zmij/pull/4. The generated code when using them is one insturction shorter, but involves one more multiplication, which is the same performance-wise, but I find this much more readable.

No performance impact, code gets shorter by 13 instructions in my godbolt test 
    main branch: https://godbolt.org/z/c68jGa6vv
    this: https://godbolt.org/z/977E3371o

A first attmept at using 128bit BCD turned out much slower. I also tried various ways to get rid of the division to extract `a` (i.e. the usually zero first digit) but they all had negative performance impact.

I couldn't remove the digits2 table yet because it is also used when formatting the exponent where a similar pseudo-smd bcd trick is not available. Using the limited range of numbers (abs(exp) < 350) allows simplifying the calculation but no matter which way I phrase the direct calculation I see a fairly consistent degradation by 1ns, i.e. 5%.

