### PR TITLE
fixes for x64 and arm64 msvc targets

### DIFF
--- a/zmij-test.cc
+++ b/zmij-test.cc
@@ -11,7 +11,6 @@ auto dtoa(double value) -> std::string {
 }
 
 TEST(zmij_test, utilities) {
-  EXPECT_EQ(count_lzero(0), 64);
   EXPECT_EQ(count_lzero(1), 63);
   EXPECT_EQ(count_lzero(~0ull), 0);
 


### PR DESCRIPTION
Multiple improvements for MSVC targets:

1) better codegen for x64 using 64-bit addition & multiply intrinsics
2) better codegen for arm64 using umulh intrinsic
3) use bsr intrinsic for arm64 and non-avx2 targets instead of lzcnt. On arm64 there's no lzcnt intrinsic. And using lzcnt on x64 without bmi extension check would give wrong result as `63-value` because instruction would execute just as "bsr". The assumption is that if user enables avx2 target for msvc, then bmi is present on all such cpu's
4) fixes umul128 fallback code when doing carry in crossover sum - this calculated wrong value, because first addition was performed in 32-bit, so carry was lost
5) fixes warnings in C code when returning void function result
