### PR TITLE
Make exponent handling branch-free

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -999,12 +999,9 @@ void dtoa(double value, char* buffer) noexcept {
   start[1] = '.';
 
   *buffer++ = 'e';
-  char sign = '+';
-  if (dec_exp < 0) {
-    sign = '-';
-    dec_exp = -dec_exp;
-  }
-  *buffer++ = sign;
+  *buffer++ = '+' + (dec_exp < 0) * ('-' - '+');
+  int mask = dec_exp >> 31;
+  dec_exp = ((dec_exp + mask) ^ mask); // absolute value
   auto [a, bb] = divmod100(uint32_t(dec_exp));
   *buffer = char('0' + a);
   buffer += dec_exp >= 100;


### PR DESCRIPTION
A surprising speedup > 1ns, i.e. ~7% on my PC with GCC 13.3

I don't know if my version of GCC just sucks, but this was surprising. Especially taking into account that gcc recognizes the bit trick and converts it to `mov eax, edx; neg eax; cmovs edx, eax` or similar. In the graph zmij_new is the modified version, zmij is the current main (taking into account that you're working on it right now it may not be current as I type this).

<img width="1670" height="1230" alt="image" src="https://github.com/user-attachments/assets/f0ef49f0-479f-4bfb-be25-e024269ac24b" />
