### PR TITLE
Improve portability.

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -1017,9 +1017,9 @@ void dtoa(double value, char* buffer) noexcept {
   start[1] = '.';
 
   *buffer++ = 'e';
-  *buffer++ = '+' + (dec_exp < 0) * ('-' - '+');
-  int mask = dec_exp >> 31;
-  dec_exp = (dec_exp + mask) ^ mask;  // absolute value
+  *buffer++ = '-' + (dec_exp >= 0) * ('+' - '-');
+  int mask = (dec_exp >= 0) - 1;
+  dec_exp = ((dec_exp + mask) ^ mask);  // absolute value
   auto [a, bb] = divmod100(uint32_t(dec_exp));
   *buffer = char('0' + a);
   buffer += dec_exp >= 100;


### PR DESCRIPTION
This should restore compatibility with non-octet architectures with arbitrary int-widths.