### PR TITLE
Trim leading zero from floats

### DIFF
--- a/test/zmij-test.cc
+++ b/test/zmij-test.cc
@@ -97,7 +97,7 @@ TEST(dtoa_test, all_exponents) {
 
 TEST(ftoa_test, normal) {
   EXPECT_EQ(ftoa(6.62607e-34f), "6.62607e-34");
-  EXPECT_EQ(ftoa(9.061488e15f), "0.9061488e+16");
+  EXPECT_EQ(ftoa(9.061488e15f), "9.061488e+15");
 }
 
 TEST(ftoa_test, subnormal) {

--- a/zmij.cc
+++ b/zmij.cc
@@ -1098,7 +1098,7 @@ template <typename Float> void to_string(Float value, char* buffer) noexcept {
     buffer = write_significand9(buffer + 1, dec_sig);
   }
   dec_exp += num_digits;
-  if (subnormal) [[unlikely]] {
+  if (subnormal || num_bits == 32) [[unlikely]] {
     char* p = start + 1;
     while (*p == '0') ++p;
     int num_zeros = int(p - (start + 1));


### PR DESCRIPTION
Before: `0.9061488e+16`
After: `9.061488e+15`

There may be a more efficient way to accomplish this.