### PR TITLE
Replace memcpy with memmove for safety

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -1100,7 +1100,7 @@ template <typename Float> void to_string(Float value, char* buffer) noexcept {
     char* p = start + 1;
     while (*p == '0') ++p;
     int num_zeros = int(p - (start + 1));
-    memcpy(start + 1, p, unsigned(num_digits - num_zeros + 1));
+    memmove(start + 1, p, unsigned(num_digits - num_zeros + 1));
     dec_exp -= num_zeros;
     buffer -= num_zeros;
     buffer -= buffer == start + 2;


### PR DESCRIPTION
I think if there are more digits than zeros, the ranges do overlap, so `memcpy` is not safe.

If this can be proven that the ranges do not overlap, a comment should be made. It is possible to use `memcpy` for non-overlapping parts of the same array safely.

Other occurrences of `memcpy` look safe, as they have distinct arrays as source and target.

Note that as the length is variable, no aggressive `memcpy` optimization were possible here anyway.

In MSVC, nothing bad will happen in this particular case, but formally it is still UB, and Address Sanitizer will alert.
