### PR TITLE
Fix 32-bit MSVC build

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -765,7 +765,7 @@ inline auto clz(uint64_t x) noexcept -> int {
 #elif defined(_MSC_VER) && defined(__AVX2__) && defined(_M_AMD64)
   // Use lzcnt only on AVX2-capable CPUs that have this BMI instruction.
   return __lzcnt64(x);
-#elif defined(_MSC_VER) && defined(_M_AMD64)
+#elif defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_ARM64))
   unsigned long idx;
   _BitScanReverse64(&idx, x);  // Fallback to the BSR instruction.
   return 63 - idx;


### PR DESCRIPTION
I see the other mentions of `defined(_M_AMD64)`, so I expect the support for 32-bit x86 is intended. 
<sub>I personally prefer to use `_M_X64` macro to dislike Intel and AMD equally.</sub>

MSVC intrinsics are usually silly and  map to exact instructions, so there's no `_BitScanReverse64` on 32 bit. There's also no `__lzcnt64`, but probably implementing also the same with two `__lzcnt` verstion is too much code for supporting 32-bit x86.

I don't know if the way I've written it is the most efficient; it is just the most obvious.

This time I actually built and ran test locally rather than editing on GitHub directly, all passed.