### PR TITLE
Support more concurrency in verify program

### DIFF
--- a/test/verify.cc
+++ b/test/verify.cc
@@ -6,7 +6,6 @@
 #include <stdio.h>   // printf
 #include <string.h>  // memcpy
 
-#include <bitset>
 #include <limits>
 #include <thread>
 #include <vector>


### PR DESCRIPTION
The verify program assumes that hardware concurrency divides evenly on number of floats.
This effectively assumes that hardware concurrency is a power of two.

Unfortunately, this assumption is quite often not valid these days. Many CPUs produced by Intel have non power of two number of cores, like six cores. After starting to have P cores and E cores, things got wilder. For example, one popular CPU has 6 P cores with simultaneous multithreading, 8 E cores without SMT, and 2 very E cores, making up total hardware concurrency equal to 22.

We have to accept this as _the new normal_.