### PR TITLE
Force inline in other C++ dialect

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -52,7 +52,7 @@
 #endif
 
 #ifdef _MSC_VER
-#  define ZMIJ_INLINE __forceinline inline
+#  define ZMIJ_INLINE __forceinline
 #elif defined(__has_attribute) && __has_attribute(always_inline)
 #  define ZMIJ_INLINE __attribute__((always_inline)) inline
 #else


### PR DESCRIPTION
This also avoids undefined(undefined) situation again