### PR TITLE
Add C++17 to yet another test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_zmij_test(zmij-no-builtins-test)
 target_compile_definitions(zmij-no-simd-test PRIVATE ZMIJ_NO_BUILTINS=1)
 
 add_executable(pow10-test pow10-test.cc)
+target_compile_features(pow10-test PRIVATE ${ZMIJ_STANDARD})
 add_test(NAME pow10-test COMMAND pow10-test)
 target_link_libraries(pow10-test gtest)
 


### PR DESCRIPTION
In case you wonder what prevents it to compile in C++14 mode, it is structured binidings:
```
zmij\zmij.cc(122): warning C5051: attribute [[maybe_unused]] requires at least '/std:c++17'; ignored
zmij\zmij.cc(126): warning C5051: attribute [[maybe_unused]] requires at least '/std:c++17'; ignored
zmij\zmij.cc(137): warning C5051: attribute [[maybe_unused]] requires at least '/std:c++17'; ignored
zmij\zmij.cc(209): error C2429: language feature 'structured bindings' requires compiler flag '/std:c++17'
zmij\zmij.cc(615): error C2429: language feature 'structured bindings' requires compiler flag '/std:c++17'
```