### PR TITLE
Reduce float_buffer_size from 17 to 16

### DIFF
--- a/zmij.h
+++ b/zmij.h
@@ -33,7 +33,7 @@ auto to_decimal(double value) noexcept -> dec_fp;
 
 enum {
   double_buffer_size = 25,
-  float_buffer_size = 17,
+  float_buffer_size = 16,
 };
 
 /// Writes the shortest correctly rounded decimal representation of `value` to


### PR DESCRIPTION
Size 16 is big enough to fit `-1.00000005e+15` (15 characters) plus nul terminator. 17 is unnecessary for any float representation currently produced by zmij::write.

Closes #51.