### PR TITLE
Compile Neon vectorization on Arm64 MSVC

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -356,7 +356,7 @@ constexpr uint64_t zeros = 0x0101010101010101u * '0';
 // Writes a significand consisting of up to 17 decimal digits (16-17 for
 // normals) and removes trailing zeros.
 auto write_significand17(char* buffer, uint64_t value) noexcept -> char* {
-#  if !ZMIJ_USE_NEON
+#if !ZMIJ_USE_NEON
   char* start = buffer;
   // Each digit is denoted by a letter so value is abbccddeeffgghhii.
   uint32_t abbccddee = uint32_t(value / 100'000'000);
@@ -371,13 +371,13 @@ auto write_significand17(char* buffer, uint64_t value) noexcept -> char* {
   bcd = to_bcd8(ffgghhii);
   write8(buffer + 8, bcd | zeros);
   return buffer + 8 + count_trailing_nonzeros(bcd);
-#else   // ZMIJ_USE_NEON
+#else  // ZMIJ_USE_NEON
   // An optimized version for NEON by Dougall Johnson.
   struct to_string_constants {
     uint64_t mul_const = 0xabcc77118461cefd;
     uint64_t hundred_million = 100000000;
     int32_t multipliers32[4] = {0x68db8bb, -10000 + 0x10000, 0x147b000,
-                                   -100 + 0x10000};
+                                -100 + 0x10000};
     int16_t multipliers16[8] = {0xce0, -10 + 0x100};
   };
 
@@ -389,7 +389,7 @@ auto write_significand17(char* buffer, uint64_t value) noexcept -> char* {
   // Compiler barrier, or clang doesn't load from memory and generates 15 more
   // instructions
   asm("" : "+r"(c));
-#endif
+#  endif
 
   uint64_t hundred_million = c->hundred_million;
 


### PR DESCRIPTION
I'm not sure if this works in MSVC, but at least it compiles, and seem to be minimal changes.

Changes:
1. Preprocessor `defined(_MSC_VER) && defined(_M_ARM64)` is the only condition for Neon, we assume Neon as a requirement of Windows on Arm64, and don't check for it.
2. Stuff the values into the structure with constants member initializers, rather than having designated initializer. MSVC only accepts designated initializer in C++20 or newer mode.
3. Use arrays in the structure with constants. These opaque types for vector intrinsic aren't necessarily arrays, but the code uses them as arrays, and not as vector intrinsic types.
4. Compiler barriers. MSVC doesn't have functioning `asm` statement. ~~There are `_ReadWriteBarrier()`, `_ReadBarrier()`, `_WriteBarrier()`, but these are for the whole code. For particular variables there are special load/store intrinsic that serve the same purpose as `asm` statement. Unfortunately, not for vector-sized variables.~~ no barriers for now.
5. MSVC lacks built-in 128 bit integers, used the integer class instead.

The uint128 change and the vector types change are applied unconditionally, not just for MSVC, so please check if the perf isn't ruined.