### PR TITLE
Lower the standard to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(zmij CXX)
 
-set(ZMIJ_STANDARD cxx_std_17)
+set(ZMIJ_STANDARD cxx_std_14)
 
 add_library(zmij zmij.cc zmij.h)
 target_include_directories(zmij PUBLIC .)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ target_compile_features(pow10-test PRIVATE ${ZMIJ_STANDARD})
 add_test(NAME pow10-test COMMAND pow10-test)
 target_link_libraries(pow10-test gtest)
 
+set(ZMIJ_BENCHMARK_STANDARD cxx_std_17)
 set(ZMIJ_CHECK_STANDARD cxx_std_20)
 
 add_executable(float-check float-check.cc)
@@ -34,7 +35,7 @@ target_include_directories(float-check PRIVATE .)
 target_link_libraries(float-check dragonbox zmij)
 
 add_executable(benchmark benchmark.cc zmij-benchmark.cc fmt/format.cc)
-target_compile_features(benchmark PRIVATE ${ZMIJ_STANDARD})
+target_compile_features(benchmark PRIVATE ${ZMIJ_BENCHMARK_STANDARD})
 if (MSVC)
   target_compile_options(benchmark PRIVATE /utf-8)
 endif()

--- a/test/zmij-test.cc
+++ b/test/zmij-test.cc
@@ -133,7 +133,7 @@ TEST(dtoa_test, no_buffer) {
   double value = 6.62607015e-34;
   auto n = zmij::write(nullptr, 0, value);
   std::string result(n, '\0');
-  zmij::write(result.data(), n, value);
+  zmij::write(&result[0], n, value);
   EXPECT_EQ(result, "6.62607015e-34");
 }
 
@@ -169,7 +169,7 @@ TEST(ftoa_test, no_buffer) {
   float value = 6.62607e-34;
   auto n = zmij::write(nullptr, 0, value);
   std::string result(n, '\0');
-  zmij::write(result.data(), n, value);
+  zmij::write(&result[0], n, value);
   EXPECT_EQ(result, "6.62607e-34");
 }
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -68,6 +68,12 @@ struct dec_fp {
 #  define ZMIJ_UNLIKELY
 #endif
 
+#if ZMIJ_HAS_CPP_ATTRIBUTE(maybe_unused)
+#  define ZMIJ_MAYBE_UNUSED maybe_unused
+#else
+#  define ZMIJ_MAYBE_UNUSED
+#endif
+
 #if ZMIJ_HAS_ATTRIBUTE(always_inline)
 #  define ZMIJ_INLINE __attribute__((always_inline)) inline
 #elif defined(_MSC_VER)
@@ -138,11 +144,11 @@ struct uint128 {
   uint64_t hi;
   uint64_t lo;
 
-  [[maybe_unused]] explicit constexpr operator uint64_t() const noexcept {
+  [[ZMIJ_MAYBE_UNUSED]] explicit constexpr operator uint64_t() const noexcept {
     return lo;
   }
 
-  [[maybe_unused]] constexpr auto operator>>(int shift) const noexcept
+  [[ZMIJ_MAYBE_UNUSED]] constexpr auto operator>>(int shift) const noexcept
       -> uint128 {
     if (shift == 32) {
       uint64_t hilo = uint32_t(hi);
@@ -153,7 +159,7 @@ struct uint128 {
   }
 };
 
-[[maybe_unused]] inline auto operator+(uint128 lhs, uint128 rhs) noexcept
+[[ZMIJ_MAYBE_UNUSED]] inline auto operator+(uint128 lhs, uint128 rhs) noexcept
     -> uint128 {
 #if defined(_MSC_VER) && defined(_M_AMD64)
   uint64_t lo, hi;


### PR DESCRIPTION
Low effort PR. Resolves #61.
 * Lower the standard of the library and tests to C++14
 * Keep benchmark standard C++17 for `from_chars`
 * Change `vector::data()` to what we did when we were young
 * Wrap `[[maybe_unused]]` into a macro. I honestly dunno what does it do here, maybe it is really unused?