### PR TITLE
Use ternary for absolute value to recover 10% performance with GCC

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -767,8 +767,7 @@ auto write(Float value, char* buffer) noexcept -> char* {
   if (is_big_endian()) e_sign = e_sign << 8 | e_sign >> 8;
   memcpy(buffer, &e_sign, 2);
   buffer += 2;
-  int mask = (dec_exp >= 0) - 1;
-  dec_exp = ((dec_exp + mask) ^ mask);  // absolute value
+  dec_exp = dec_exp >= 0 ? dec_exp : -dec_exp;
   if (traits::min_exponent10 >= -99 && traits::max_exponent10 <= 99) {
     memcpy(buffer, digits2(dec_exp), 2);
     buffer[2] = '\0';


### PR DESCRIPTION
This fixes a performance issue introduced by using a bit trick that confuses gcc. The simple ternary does the job, giving a nice conditional move which staves off some 10% of execution time both on my office PC and my laptop (much easier to measure with the new benchmark tool, thanks!). The performance regression was discovered here: https://github.com/vitaut/zmij/pull/60#issuecomment-3727874657

I think I originally introduced the bit trick to work around gcc not optimizing the ternary in the original context, but in the current incarnation of the code this is clearly superior both in performance and readability. clang produces identical code before and after the change. I added a bug to gcc http://gcc.gnu.org/PR123505 (actually two bugs, but the second is about further mis-optimization after this misoptimization http://gcc.gnu.org/PR123506)

BTW I think the exponent printing may be overrepresented in that performance number because the benchmark uses significands with fixed numbers of digits but varies the exponents over the full range. In real workloads three-digit exponents are probably quite rare. I've certainly only ever seen them when printing uninitialized variables.
