### PR TITLE
Don't use vector types on MSVC as arrays

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -503,8 +503,8 @@ auto write_significand17(char* buffer, uint64_t value,
   constexpr int32_t neg10k = -10000 + 0x10000;
   struct to_string_constants {
 #ifdef _MSC_VER
-    using int32x4_t = __declspec(align(16)) std::int32_t[4];
-    using int16x8_t = __declspec(align(16)) std::int16_t[8];
+    using int32x4_t = std::int32_t[4];
+    using int16x8_t = std::int16_t[8];
 #endif
     uint64_t mul_const = 0xabcc77118461cefd;
     uint64_t hundred_million = 100000000;


### PR DESCRIPTION
I dunno if `alignas(16)` instead of this will work