### PR TITLE
Peel off rightmost digit to gain cheaper division, avoid zero check, …

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -577,13 +577,9 @@ auto write_significand17(char* buffer, uint64_t value,
   buffer += 16 - ((zeroes != 0 ? clz(zeroes) : 64) >> 2);
   return buffer - int(buffer - start == 1);
 #elif ZMIJ_USE_SSE
-#  if ZMIJ_USE_INT128 == 1
-  constexpr int div10_exp = 64;
-  constexpr uint128_t div10_sig = (uint128_t(1) << div10_exp) / 10 + 1;
-  uint64_t digits_16 = uint64_t((value * div10_sig) >> div10_exp);
-#  else  // !ZMIJ_USE_INT128
-  uint64_t digits_16 = value / 10;
-#  endif  // ZMIJ_USE_INT128
+  // Divide by ten with a 64bit shift.  Note that (1 << 63) / 5 == (1 << 64) / 10
+  // but doesn't need an intermediate int128.
+  uint64_t digits_16 = use_umul128_hi64 ? umul128_hi64((1ull << 63) / 5 + 1, value) : value / 10;
   uint32_t last_digit = value - digits_16 * 10;
 
   // We always write 17 digits into the buffer, but the first one can be zero.


### PR DESCRIPTION
…and make writing simpler.  A 10% performance gain.

This patch is derived from a remark Xiang JunBo made about significand lengths in one of the comments on the SIMD patches where he discussed the length of the significand and the last digit. This made me think about how to deal with the 17th digit in the SIMD code which writes 16 digits at once, and thus has to special case either the first or last digit. It occurred to me that because we are limited to numbers below 1e18 we can actually express division by ten cheaply with no shift in the assembly using mulhi (using the upper 64 bits of a wide multiplication).

If one peels off the rightmost digits and then uses the SIMD code to write the top 16digits at once, one finds that the first digit of these 16digits can be zero. This happens if the decimal significand has 16 digits -- we divided it by 10 to extract the last digit, but now we have only fifteen digits. And here is where the magic happens: because we allocate one extra byte in front of the buffer to be able to insert the decimal point, we can actually put the zero in that position, and everything falls in place without adding any branches.

This is a 10% speedup in my measurements.  On my laptop it looks like this
<img width="1442" height="1905" alt="image" src="https://github.com/user-attachments/assets/61f0a5c7-34d4-4f44-b873-eeb6a11d308e" />

On my office PC it takes the benchmark time from 10.5ns to 9.4ns (with SSE2). So the 10ns barrier is broken also on x64.

A small additional gain is that since we know the 16digits can't all be zero, we no longer need a zero-check for `clz`. I believe the same optimization can be applied on NEON, but since I cannot test it, I only touched that code to deal with the updated signature of `write_significand17` -- with this change, the beginning of the buffer argument is moved by one byte to the left to accomodate for the potential leading '0'.