### PR TITLE
Use addition instead of OR to add zeros and thus allow use of LEA

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -506,7 +506,7 @@ auto write_significand9(char* buffer, uint32_t value, bool has9digits) noexcept
     -> char* {
   buffer = write_if(buffer, value / 100'000'000, has9digits);
   uint64_t bcd = to_bcd8(value % 100'000'000);
-  write8(buffer, bcd | zeros);
+  write8(buffer, bcd + zeros);
   return buffer + count_trailing_nonzeros(bcd);
 }
 
@@ -522,13 +522,13 @@ auto write_significand17(char* buffer, uint64_t value, bool has17digits,
     uint32_t ffgghhii = uint32_t(value % 100'000'000);
     buffer = write_if(buffer, abbccddee / 100'000'000, has17digits);
     uint64_t bcd = to_bcd8(abbccddee % 100'000'000);
-    write8(buffer, bcd | zeros);
+    write8(buffer, bcd + zeros);
     if (ffgghhii == 0) {
       write8(buffer + 8, zeros);
       return buffer + count_trailing_nonzeros(bcd);
     }
     bcd = to_bcd8(ffgghhii);
-    write8(buffer + 8, bcd | zeros);
+    write8(buffer + 8, bcd + zeros);
     return buffer + 8 + count_trailing_nonzeros(bcd);
   }
 #if ZMIJ_USE_NEON


### PR DESCRIPTION
I don't believe my benchmarks here, but if I were to trust them this is a speed increase by 0.5ns in the `ZMIJ_NO_SIMD` case before the fixed format was added which breaks gcc's optimization. After it seems to be lost in the noise. It saves one assembly instruction in the output (not three as I hoped -- I wrote this before the fixed output was added which adds more opportunities). Check https://godbolt.org/z/86TT7MoGx which defines `OP` either as `+` or as `|` to allow for a straightforward comparison.

The idea here is that when we convert the BCD number into a string we used the logically correct bitwise `OR` operation, but using the `ADD` operation instead enables the use of the `LEA` instruction and thus (see around line 34 in the GCC output (which no longer inlines write_significand17,  probably because its shared with the fixed format), similarly in line 666 of clang's output)
```
        mov     r11, rdx
        or      r11, rcx
```` 
becomes simply
```
        lea     r11, [rdx+rcx]
```
I can't read arm assembly well, so I'm not going to make any guesses there.

(I originally pushed this to my fork with the last known revision where SSE works, but since this is irrelevant to this, I updated it to the main branch while writing the PR, hence the forced push.)
