### PR TITLE
Fix clang compile errors

### DIFF
--- a/zmij.c
+++ b/zmij.c
@@ -1090,10 +1090,8 @@ typedef struct {
 #endif
 
 #define ZMIJ_SPLAT64(x) {(long long)(x), (long long)(x)}
-#define ZMIJ_SPLAT32(x) \
-  ZMIJ_SPLAT64((uint64_t)(uint32_t)(x) << 32 | (uint32_t)(x))
-#define ZMIJ_SPLAT16(x) \
-  ZMIJ_SPLAT32((uint32_t)(uint16_t)(x) << 16 | (uint16_t)(x))
+#define ZMIJ_SPLAT32(x) ZMIJ_SPLAT64((uint64_t)(x) << 32 | (uint64_t)(x))
+#define ZMIJ_SPLAT16(x) ZMIJ_SPLAT32((uint64_t)(x) << 16 | (uint64_t)(x))
 #define ZMIJ_PACK8(a, b, c, d, e, f, g, h)                           \
   ((uint64_t)(h) << 56 | (uint64_t)(g) << 48 | (uint64_t)(f) << 40 | \
    (uint64_t)(e) << 32 | (uint64_t)(d) << 24 | (uint64_t)(c) << 16 | \


### PR DESCRIPTION
Fix the following compile errors given by`clang -c -msse4.1 -std=gnu11 -DZMIJ_USE_SSE4_1=1 -DZMIJ_USE_SSE=1 zmij.c`

```
zmij.c:52:47: warning: '_Static_assert' with no message is a C23 extension [-Wc23-extensions]
   52 | static_assert(!ZMIJ_USE_SSE4_1 || ZMIJ_USE_SSE);
      |                                               ^
      |                                               , ""
zmij.c:1086:1: error: unknown type name 'using'
 1086 | using m128i = __m128i;
      | ^
zmij.c:1086:15: error: unexpected type name '__m128i': expected expression
 1086 | using m128i = __m128i;
      |               ^
zmij.c:1093:8: error: unknown type name 'm128i'
 1093 | static m128i splat64(uint64_t x) {
      |        ^
zmij.c:1094:8: error: expected ';' after expression
 1094 |   m128i result = {(long long)x, (long long)x};
      |        ^
      |        ;
zmij.c:1094:9: error: use of undeclared identifier 'result'
 1094 |   m128i result = {(long long)x, (long long)x};
      |         ^~~~~~
zmij.c:1094:18: error: expected expression
 1094 |   m128i result = {(long long)x, (long long)x};
      |                  ^
zmij.c:1095:10: error: use of undeclared identifier 'result'
 1095 |   return result;
      |          ^~~~~~
zmij.c:1097:8: error: unknown type name 'm128i'
 1097 | static m128i splat32(uint32_t x) { return splat64((uint64_t)x << 32 | x); }
      |        ^
zmij.c:1098:8: error: unknown type name 'm128i'
 1098 | static m128i splat16(uint16_t x) { return splat32((uint32_t)x << 16 | x); }
      |        ^
zmij.c:1236:5: error: unknown type name 'm128i'
 1236 |     m128i div10k = splat64(div10k_sig);
      |     ^
zmij.c:1236:17: error: expected ';' at end of declaration list
 1236 |     m128i div10k = splat64(div10k_sig);
      |                 ^
      |                 ;
zmij.c:1237:5: error: unknown type name 'm128i'
 1237 |     m128i neg10k = splat64(::neg10k);
      |     ^
zmij.c:1237:17: error: expected ';' at end of declaration list
 1237 |     m128i neg10k = splat64(::neg10k);
      |                 ^
      |                 ;
zmij.c:1238:5: error: unknown type name 'm128i'
 1238 |     m128i div100 = splat32(div100_sig);
      |     ^
zmij.c:1238:17: error: expected ';' at end of declaration list
 1238 |     m128i div100 = splat32(div100_sig);
      |                 ^
      |                 ;
zmij.c:1239:5: error: unknown type name 'm128i'
 1239 |     m128i div10 = splat16((1 << 16) / 10 + 1);
      |     ^
zmij.c:1239:16: error: expected ';' at end of declaration list
 1239 |     m128i div10 = splat16((1 << 16) / 10 + 1);
      |                ^
      |                ;
zmij.c:1241:5: error: unknown type name 'm128i'
 1241 |     m128i neg100 = splat32(::neg100);
      |     ^
zmij.c:1241:17: error: expected ';' at end of declaration list
 1241 |     m128i neg100 = splat32(::neg100);
      |                 ^
      |                 ;
fatal error: too many errors emitted, stopping now [-ferror-limit=]
1 warning and 20 errors generated.
```

The code is formatted using clang-format.