### PR TITLE
Apply settings to the correct test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ add_zmij_test(zmij-no-simd-test)
 target_compile_definitions(zmij-no-simd-test PRIVATE ZMIJ_USE_SIMD=0)
 
 add_zmij_test(zmij-no-builtins-test)
-target_compile_definitions(zmij-no-simd-test PRIVATE ZMIJ_NO_BUILTINS=1)
+target_compile_definitions(zmij-no-builtins-test PRIVATE ZMIJ_NO_BUILTINS=1)
 
 add_zmij_test(zmij-optimize-size-test)
 target_compile_definitions(zmij-optimize-size-test PRIVATE ZMIJ_OPTIMIZE_SIZE=1)


### PR DESCRIPTION
By divine law every test introduces at least one new bug. Here's proof that the universe is still in balance.

The no-simd test was compiled with no-builtins on top of no-simd, and the no-builtins test was built with default settings. I resisted the temptation to enumerate all combinations of flags to retain the added test coverage this typo achieved, instead I only fixed the typo.