### PR TITLE
Avoid disallowed conversion from unsigned int to int

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -834,9 +834,9 @@ ZMIJ_INLINE auto to_digits(char*& buffer, uint64_t value,
   __m128i mask128 = _mm_cmpgt_epi8(bcd, _mm_setzero_si128());
   uint64_t mask = _mm_movemask_epi8(mask128);
 #  if defined(__LZCNT__) && !defined(ZMIJ_NO_BUILTINS)
-  auto len = 32 - _lzcnt_u32(mask);
+  int len = 32 - _lzcnt_u32(mask);
 #  else
-  auto len = 63 - clz((mask << 1) | 1);
+  int len = 63 - clz((mask << 1) | 1);
 #  endif
   return {_mm_or_si128(bcd, zeros), len};
 #endif  // ZMIJ_USE_SSE


### PR DESCRIPTION
`_lzcnt_u32` returns an `unsigned int` so `len` becomes `unsigned int` with `-march=x86-64-v3` where LZCNT is available. The constructor for the return value on the next line expects int. Fixed by making the type explicit in both `#ifdef` branches.

WRT my other PR, I'm still trying to figure out if your new table (also included when optimizing for size BTW) can be leveraged or integrated for the SSE code.