### PR TITLE
Add windows ci, Fix node20 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,15 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: cmake -B build
       - run: cmake --build build -j
       - run: ctest --test-dir build --output-on-failure
+
+  build-msvc:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: cmake -B build
+      - run: cmake --build build --config Debug -j
+      - run: ctest --test-dir build -C Debug --output-on-failure


### PR DESCRIPTION
Add a ci for MSVC compiler, its behavior may differ from gcc/clang.

I encountered some compile errors on my Windows but it didn't show up on ci :/