### PR TITLE
SIMD for floats

### DIFF
--- a/test/double-check.cc
+++ b/test/double-check.cc
@@ -67,9 +67,9 @@ inline auto verify(uint64_t bits, uint64_t bin_sig, int bin_exp, int raw_exp,
   uint32_t ffgghhii = uint32_t(actual_sig % 100'000'000);
   int num_zeros = 0;
   if (ffgghhii == 0)
-    num_zeros = 16 - count_trailing_nonzeros(to_bcd8(abbccddee % 100'000'000));
+    num_zeros = 16 - to_bcd8(abbccddee % 100'000'000).len;
   else
-    num_zeros = 8 - count_trailing_nonzeros(to_bcd8(ffgghhii));
+    num_zeros = 8 - to_bcd8(ffgghhii).len;
   if (num_zeros != 0) {
     expected.significand *= pow10[num_zeros];
     expected.exponent -= num_zeros;

--- a/test/zmij-test.cc
+++ b/test/zmij-test.cc
@@ -237,6 +237,12 @@ TEST(dtoa_test, to_decimal) {
   dec = zmij::to_decimal(garlic_nan);
   EXPECT_EQ(dec.sig, garlic);
 }
+
+TEST(ftoa_test, fixed_with_zeros) {
+  EXPECT_EQ(ftoa(43210.0f), "43210");
+  EXPECT_EQ(ftoa(43210.1f), "43210.1");
+  EXPECT_EQ(ftoa(10000.f), "10000");
+}
 #endif  // ZMIJ_C
 
 TEST(dtoa_test, no_overrun) {
@@ -267,12 +273,6 @@ TEST(ftoa_test, no_overrun) {
   auto n = zmij::write(buffer, zmij::float_buffer_size, -1.00000005e+15f);
   EXPECT_EQ(std::string(buffer, n), std::string("-1.00000005e+15"));
   EXPECT_EQ(buffer[zmij::float_buffer_size], '?');
-}
-
-TEST(ftoa_test, fixed_with_zeros) {
-  EXPECT_EQ(ftoa(43210.0f), "43210");
-  EXPECT_EQ(ftoa(43210.1f), "43210.1");
-  EXPECT_EQ(ftoa(10000.f), "10000");
 }
 
 auto main(int argc, char** argv) -> int {

--- a/test/zmij-test.cc
+++ b/test/zmij-test.cc
@@ -269,6 +269,12 @@ TEST(ftoa_test, no_overrun) {
   EXPECT_EQ(buffer[zmij::float_buffer_size], '?');
 }
 
+TEST(ftoa_test, fixed_with_zeros) {
+  EXPECT_EQ(ftoa(43210.0f), "43210");
+  EXPECT_EQ(ftoa(43210.1f), "43210.1");
+  EXPECT_EQ(ftoa(10000.f), "10000");
+}
+
 auto main(int argc, char** argv) -> int {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/zmij.cc
+++ b/zmij.cc
@@ -709,22 +709,41 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
 #endif  // ZMIJ_USE_SSE
 
 #if ZMIJ_USE_NEON
+// An optimized version for NEON by Dougall Johnson.
+  
+alignas(64) static constexpr struct neon_constants {
+  static constexpr int32_t neg10k = -10000 + 0x10000;
+  
+  using int32x4 = std::conditional_t<ZMIJ_MSC_VER != 0, int32_t[4], int32x4_t>;
+  using int16x8 = std::conditional_t<ZMIJ_MSC_VER != 0, int16_t[8], int16x8_t>;
+
+  uint64_t mul_const = 0xabcc77118461cefd;
+  uint64_t hundred_million = 100000000;
+  int32x4 multipliers32 = {div10k_sig, neg10k, div100_sig << 12, neg100};
+  int16x8 multipliers16 = {0xce0, neg10};
+} neon_consts;
+
+ZMIJ_INLINE auto to_digits_4x4digits(int32x4_t ddee_bbcc_hhii_ffgg, const neon_constants* c) noexcept
+  -> uint8x16_t {
+  // Compiler barrier, or clang breaks the subsequent MLA into UADDW + MUL.
+  ZMIJ_ASM(("" : "+w"(ddee_bbcc_hhii_ffgg)));
+
+  int32x4_t dd_bb_hh_ff =
+      vqdmulhq_n_s32(ddee_bbcc_hhii_ffgg, c->multipliers32[2]);
+  int16x8_t ee_dd_cc_bb_ii_hh_gg_ff = vreinterpretq_s16_s32(
+      vmlaq_n_s32(ddee_bbcc_hhii_ffgg, dd_bb_hh_ff, c->multipliers32[3]));
+  int16x8_t high_10s =
+      vqdmulhq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, c->multipliers16[0]);
+  return vreinterpretq_u8_s16(
+      vmlaq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, high_10s, c->multipliers16[1]));
+}
+
 // When reverse_hi_lo is true, the two 8-digit halves are returned in reversed
 // order so that trailing zeros become leading zero bytes, letting ctz count
 // them while the shuffle runs in parallel.
 template <bool reverse_hi_lo = false>
 ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
-  // An optimized version for NEON by Dougall Johnson.
-  using int32x4 = std::conditional_t<ZMIJ_MSC_VER != 0, int32_t[4], int32x4_t>;
-  using int16x8 = std::conditional_t<ZMIJ_MSC_VER != 0, int16_t[8], int16x8_t>;
-  constexpr int32_t neg10k = -10000 + 0x10000;
-  alignas(64) static constexpr struct {
-    uint64_t mul_const = 0xabcc77118461cefd;
-    uint64_t hundred_million = 100000000;
-    int32x4 multipliers32 = {div10k_sig, neg10k, div100_sig << 12, neg100};
-    int16x8 multipliers16 = {0xce0, neg10};
-  } consts;
-  const auto* c = &consts;
+  const auto* c = &neon_consts;
 
   // Compiler barrier, or clang doesn't load from memory and generates 15 more
   // instructions.
@@ -744,7 +763,8 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
   uint64x1_t ffgghhii_bbccddee_64 = {
       reverse_hi_lo ? (uint64_t(abbccddee) << 32) | ffgghhii
                     : (uint64_t(ffgghhii) << 32) | abbccddee};
-  int32x2_t bbccddee_ffgghhii = vreinterpret_s32_u64(ffgghhii_bbccddee_64);
+
+                      int32x2_t bbccddee_ffgghhii = vreinterpret_s32_u64(ffgghhii_bbccddee_64);
 
   int32x2_t bbcc_ffgg = vreinterpret_s32_u32(
       vshr_n_u32(vreinterpret_u32_s32(
@@ -756,17 +776,7 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
   int32x4_t ddee_bbcc_hhii_ffgg = vreinterpretq_s32_u32(
       vshll_n_u16(vreinterpret_u16_s32(ddee_bbcc_hhii_ffgg_32), 0));
 
-  // Compiler barrier, or clang breaks the subsequent MLA into UADDW + MUL.
-  ZMIJ_ASM(("" : "+w"(ddee_bbcc_hhii_ffgg)));
-
-  int32x4_t dd_bb_hh_ff =
-      vqdmulhq_n_s32(ddee_bbcc_hhii_ffgg, c->multipliers32[2]);
-  int16x8_t ee_dd_cc_bb_ii_hh_gg_ff = vreinterpretq_s16_s32(
-      vmlaq_n_s32(ddee_bbcc_hhii_ffgg, dd_bb_hh_ff, c->multipliers32[3]));
-  int16x8_t high_10s =
-      vqdmulhq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, c->multipliers16[0]);
-  return vreinterpretq_u8_s16(
-      vmlaq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, high_10s, c->multipliers16[1]));
+  return to_digits_4x4digits(ddee_bbcc_hhii_ffgg, c);
 }
 #endif
 
@@ -787,7 +797,7 @@ template <> struct dec_digits<64> {
 };
 
 auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
-#if !ZMIJ_USE_SSE
+#if !ZMIJ_USE_SSE && !ZMIJ_USE_NEON
   // An optimization from Xiang JunBo.
   // Three steps BCD. Base 10000 -> base 100 -> base 10.
   // div and mod are evaluated simultaneously as, e.g.
@@ -805,16 +815,28 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
       neg10 * (((ab_cd_ef_gh * div10_sig) >> div10_exp) & 0xf000f000f000f);
   return is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
 #else
+# if ZMIJ_USE_SSE
   const auto* c = &sse_consts;
   ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
 
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   auto unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
-#  if ZMIJ_USE_SSE4_1
+#   if ZMIJ_USE_SSE4_1
   return bswap64(unshuffled_bcd);
-#  else
+#    else
   return unshuffled_bcd;
+#    endif
+#  else // ZMIJ_USE_NEON
+  const auto* c = &neon_consts;
+  ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
+
+  uint64_t abcd_efgh_64 =
+      abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
+  int32x4_t abcd_efgh = vcombine_s32(vreinterpret_s32_u64(vcreate_u64(abcd_efgh_64)), vdup_n_s32(0));
+  uint8x16_t digits_128 = to_digits_4x4digits(abcd_efgh, c);
+  return vget_lane_u64(
+    vreinterpret_u64_u8(vrev64_u8(vget_low_u8(digits_128))), 0);
 #  endif
 
 #endif  // ZMIJ_USE_SSE

--- a/zmij.cc
+++ b/zmij.cc
@@ -822,26 +822,25 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
       neg10 * (((ab_cd_ef_gh * div10_sig) >> div10_exp) & 0xf000f000f000f);
   uint64_t result = is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
   return {result, count_trailing_nonzeros(result)};
-#else
-# if ZMIJ_USE_SSE
+#elif ZMIJ_USE_SSE
   const auto* c = &sse_consts;
   ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
 
-#   if ZMIJ_USE_SSE4_1
+# if ZMIJ_USE_SSE4_1
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
   int len = unshuffled_bcd ? 8 - ctz(unshuffled_bcd) / 8 : 0;
   return {bswap64(unshuffled_bcd), len};
-#    else
+#  else
   // Evaluate the 4 digit limbs and arrange them such that we get a result which
   // is in the correct order.
   uint64_t abcd_efgh =
       (uint64_t(abcdefgh) << 32) - uint64_t((10000ull << 32) - 1) * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
   return {bcd, count_trailing_nonzeros(bcd)};
-#    endif
-#  else // ZMIJ_USE_NEON
+#  endif
+#else // ZMIJ_USE_NEON
   const auto* c = &neon_consts;
   ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
 
@@ -852,8 +851,6 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   uint8x8_t digits = vget_low_u8(digits_128);
   uint64_t result = vget_lane_u64(vreinterpret_u64_u8(vrev64_u8(digits)), 0);
   return { result, count_trailing_nonzeros(result) };
-#  endif
-
 #endif  // ZMIJ_USE_SSE
 }
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -796,7 +796,12 @@ template <> struct dec_digits<64> {
   int num_digits;
 };
 
-auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
+struct bcd_result {
+  uint64_t bcd;
+  int len;
+};
+
+auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
 #if !ZMIJ_USE_SSE && !ZMIJ_USE_NEON
   // An optimization from Xiang JunBo.
   // Three steps BCD. Base 10000 -> base 100 -> base 10.
@@ -813,7 +818,8 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
   uint64_t a_b_c_d_e_f_g_h =
       ab_cd_ef_gh +
       neg10 * (((ab_cd_ef_gh * div10_sig) >> div10_exp) & 0xf000f000f000f);
-  return is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
+  uint64_t result = is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
+  return {result, count_trailing_nonzeros(result)};
 #else
 # if ZMIJ_USE_SSE
   const auto* c = &sse_consts;
@@ -823,9 +829,9 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   auto unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
 #   if ZMIJ_USE_SSE4_1
-  return bswap64(unshuffled_bcd);
+  return {bswap64(unshuffled_bcd), count_trailing_nonzeros(bswap64(unshuffled_bcd))};
 #    else
-  return unshuffled_bcd;
+  return {unshuffled_bcd, count_trailing_nonzeros(unshuffled_bcd)};
 #    endif
 #  else // ZMIJ_USE_NEON
   const auto* c = &neon_consts;
@@ -835,8 +841,9 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   int32x4_t abcd_efgh = vcombine_s32(vreinterpret_s32_u64(vcreate_u64(abcd_efgh_64)), vdup_n_s32(0));
   uint8x16_t digits_128 = to_digits_4x4digits(abcd_efgh, c);
-  return vget_lane_u64(
-    vreinterpret_u64_u8(vrev64_u8(vget_low_u8(digits_128))), 0);
+  uint8x8_t digits = vget_low_u8(digits_128);
+  uint64_t result = vget_lane_u64(vreinterpret_u64_u8(vrev64_u8(digits)), 0);
+  return { result, count_trailing_nonzeros(result) };
 #  endif
 
 #endif  // ZMIJ_USE_SSE
@@ -853,10 +860,10 @@ ZMIJ_INLINE auto to_digits(char* buffer, uint64_t value,
   // Digits/pairs of digits are denoted by letters: value = bbccddeeffgghhii.
   uint32_t bbccddee = uint32_t(value / 100'000'000);
   uint32_t ffgghhii = uint32_t(value % 100'000'000);
-  uint64_t hi = to_bcd8(bbccddee);
-  if (ffgghhii == 0) return {{hi + zeros, zeros}, count_trailing_nonzeros(hi)};
-  uint64_t lo = to_bcd8(ffgghhii);
-  return {{hi + zeros, lo + zeros}, 8 + count_trailing_nonzeros(lo)};
+  auto [hi, len_hi] = to_bcd8(bbccddee);
+  if (ffgghhii == 0) return {{hi + zeros, zeros}, len_hi};
+  auto [lo, len_lo] = to_bcd8(ffgghhii);
+  return {{hi + zeros, lo + zeros}, 8 + len_lo};
 #elif ZMIJ_USE_NEON
   auto unshuffled_digits = to_unshuffled_digits(value);
   uint8x16_t digits = vrev64q_u8(unshuffled_digits);
@@ -900,8 +907,8 @@ template <>
 ZMIJ_INLINE auto to_digits<32>(char* buffer, uint64_t value,
                                bool extra_digit) noexcept -> dec_digits<32> {
   write_if(buffer, value / 100'000'000, extra_digit);
-  uint64_t bcd = to_bcd8(value % 100'000'000);
-  return {bcd + zeros, count_trailing_nonzeros(bcd)};
+  auto [bcd, len] = to_bcd8(value % 100'000'000);
+  return {bcd + zeros, len};
 }
 
 #if ZMIJ_USE_SIMD_SHUFFLE

--- a/zmij.cc
+++ b/zmij.cc
@@ -648,6 +648,7 @@ alignas(64) constexpr struct sse_constants {
            u64(d) << 24 | u64(c) << 16 | u64(b) << +8 | u64(a);
   }
 
+  // Ordered so that the values used to format floats fit in a single cache line.
   uint128 div100 = splat32(div100_sig);
   uint128 div10 = splat16((1 << 16) / 10 + 1);
 #  if ZMIJ_USE_SSE4_1

--- a/zmij.cc
+++ b/zmij.cc
@@ -763,8 +763,7 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
   uint64x1_t ffgghhii_bbccddee_64 = {
       reverse_hi_lo ? (uint64_t(abbccddee) << 32) | ffgghhii
                     : (uint64_t(ffgghhii) << 32) | abbccddee};
-
-                      int32x2_t bbccddee_ffgghhii = vreinterpret_s32_u64(ffgghhii_bbccddee_64);
+  int32x2_t bbccddee_ffgghhii = vreinterpret_s32_u64(ffgghhii_bbccddee_64);
 
   int32x2_t bbcc_ffgg = vreinterpret_s32_u32(
       vshr_n_u32(vreinterpret_u32_s32(
@@ -829,10 +828,11 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
-  int len = unshuffled_bcd ? (71 - ctz(unshuffled_bcd)) / 8 : 0;
+  int len = unshuffled_bcd ? 8 - ctz(unshuffled_bcd) / 8 : 0;
   return {bswap64(unshuffled_bcd), len};
 #    else
-  // Ensure correct order of output.
+  // Evaluate the 4 digit limbs and arrange them such that we get a result which
+  // is in the correct order.
   uint64_t abcd_efgh =
       (uint64_t(abcdefgh) << 32) - uint64_t((10000ull << 32) - 1) * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));

--- a/zmij.cc
+++ b/zmij.cc
@@ -625,25 +625,6 @@ constexpr uint32_t neg10 = (1 << 8) - 10;
 
 constexpr uint64_t zeros = 0x0101010101010101u * '0';
 
-auto to_bcd8(uint64_t abcdefgh) noexcept -> uint64_t {
-  // An optimization from Xiang JunBo.
-  // Three steps BCD. Base 10000 -> base 100 -> base 10.
-  // div and mod are evaluated simultaneously as, e.g.
-  //   (abcdefgh / 10000) << 32 + (abcdefgh % 10000)
-  //      == abcdefgh + (2**32 - 10000) * (abcdefgh / 10000)))
-  // where the division on the RHS is implemented by the usual multiply + shift
-  // trick and the fractional bits are masked away.
-  uint64_t abcd_efgh =
-      abcdefgh + neg10k * ((abcdefgh * div10k_sig) >> div10k_exp);
-  uint64_t ab_cd_ef_gh =
-      abcd_efgh +
-      neg100 * (((abcd_efgh * div100_sig) >> div100_exp) & 0x7f0000007f);
-  uint64_t a_b_c_d_e_f_g_h =
-      ab_cd_ef_gh +
-      neg10 * (((ab_cd_ef_gh * div10_sig) >> div10_exp) & 0xf000f000f000f);
-  return is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
-}
-
 inline auto write_if(char* buffer, uint32_t digit, bool condition) noexcept
     -> char* {
   *buffer = char('0' + digit);
@@ -685,6 +666,31 @@ alignas(64) constexpr struct sse_constants {
 
 using m128ptr = const __m128i*;
 
+ZMIJ_INLINE auto to_digits_4x4digits(__m128i y, const sse_constants& c) noexcept
+  -> __m128i {
+  const __m128i div100 = _mm_load_si128(m128ptr(&c.div100));
+  const __m128i div10 = _mm_load_si128(m128ptr(&c.div10));
+#  if ZMIJ_USE_SSE4_1
+  const __m128i neg100 = _mm_load_si128(m128ptr(&c.neg100));
+  const __m128i neg10 = _mm_load_si128(m128ptr(&c.neg10));
+
+  // _mm_mullo_epi32 is SSE 4.1
+  __m128i z = _mm_add_epi64(
+      y,
+      _mm_mullo_epi32(neg100, _mm_srli_epi32(_mm_mulhi_epu16(y, div100), 3)));
+  return _mm_add_epi16(z, _mm_mullo_epi16(neg10, _mm_mulhi_epu16(z, div10)));
+#  else
+  const __m128i hundred = _mm_load_si128(m128ptr(&c.hundred));
+  const __m128i moddiv10 = _mm_load_si128(m128ptr(&c.moddiv10));
+
+  __m128i y_div_100 = _mm_srli_epi16(_mm_mulhi_epu16(y, div100), 3);
+  __m128i y_mod_100 = _mm_sub_epi16(y, _mm_mullo_epi16(y_div_100, hundred));
+  __m128i z = _mm_or_si128(_mm_slli_epi32(y_mod_100, 16), y_div_100);
+  return _mm_sub_epi16(_mm_slli_epi16(z, 8),
+                       _mm_mullo_epi16(moddiv10, _mm_mulhi_epu16(z, div10)));
+#  endif  // ZMIJ_USE_SSE4_1
+}
+
 // SSE parallel version of to_bcd8: converts bbccddee and ffgghhii into
 // individual BCD digits in SIMD lane order (caller must shuffle).
 ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
@@ -692,33 +698,13 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
     -> __m128i {
   const __m128i div10k = _mm_load_si128(m128ptr(&c.div10k));
   const __m128i neg10k = _mm_load_si128(m128ptr(&c.neg10k));
-  const __m128i div100 = _mm_load_si128(m128ptr(&c.div100));
-  const __m128i div10 = _mm_load_si128(m128ptr(&c.div10));
-#  if ZMIJ_USE_SSE4_1
-  const __m128i neg100 = _mm_load_si128(m128ptr(&c.neg100));
-  const __m128i neg10 = _mm_load_si128(m128ptr(&c.neg10));
-#  else
-  const __m128i hundred = _mm_load_si128(m128ptr(&c.hundred));
-  const __m128i moddiv10 = _mm_load_si128(m128ptr(&c.moddiv10));
-#  endif
 
   __m128i x = _mm_set_epi64x(bbccddee, ffgghhii);
   __m128i y = _mm_add_epi64(
       x, _mm_mul_epu32(neg10k,
                        _mm_srli_epi64(_mm_mul_epu32(x, div10k), div10k_exp)));
-#  if ZMIJ_USE_SSE4_1
-  // _mm_mullo_epi32 is SSE 4.1
-  __m128i z = _mm_add_epi64(
-      y,
-      _mm_mullo_epi32(neg100, _mm_srli_epi32(_mm_mulhi_epu16(y, div100), 3)));
-  return _mm_add_epi16(z, _mm_mullo_epi16(neg10, _mm_mulhi_epu16(z, div10)));
-#  else
-  __m128i y_div_100 = _mm_srli_epi16(_mm_mulhi_epu16(y, div100), 3);
-  __m128i y_mod_100 = _mm_sub_epi16(y, _mm_mullo_epi16(y_div_100, hundred));
-  __m128i z = _mm_or_si128(_mm_slli_epi32(y_mod_100, 16), y_div_100);
-  return _mm_sub_epi16(_mm_slli_epi16(z, 8),
-                       _mm_mullo_epi16(moddiv10, _mm_mulhi_epu16(z, div10)));
-#  endif  // ZMIJ_USE_SSE4_1
+
+  return to_digits_4x4digits(y, c);
 }
 #endif  // ZMIJ_USE_SSE
 
@@ -799,6 +785,41 @@ template <> struct dec_digits<64> {
 #endif
   int num_digits;
 };
+
+auto to_bcd8(uint32_t abcdefgh) noexcept -> uint64_t {
+#if !ZMIJ_USE_SSE
+  // An optimization from Xiang JunBo.
+  // Three steps BCD. Base 10000 -> base 100 -> base 10.
+  // div and mod are evaluated simultaneously as, e.g.
+  //   (abcdefgh / 10000) << 32 + (abcdefgh % 10000)
+  //      == abcdefgh + (2**32 - 10000) * (abcdefgh / 10000)))
+  // where the division on the RHS is implemented by the usual multiply + shift
+  // trick and the fractional bits are masked away.
+  uint64_t abcd_efgh =
+      abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
+  uint64_t ab_cd_ef_gh =
+      abcd_efgh +
+      neg100 * (((abcd_efgh * div100_sig) >> div100_exp) & 0x7f0000007f);
+  uint64_t a_b_c_d_e_f_g_h =
+      ab_cd_ef_gh +
+      neg10 * (((ab_cd_ef_gh * div10_sig) >> div10_exp) & 0xf000f000f000f);
+  return is_big_endian ? a_b_c_d_e_f_g_h : bswap64(a_b_c_d_e_f_g_h);
+#else
+  const auto* c = &sse_consts;
+  ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
+
+  uint64_t abcd_efgh =
+      abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
+  auto unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
+#  if ZMIJ_USE_SSE4_1
+  return bswap64(unshuffled_bcd);
+#  else
+  return unshuffled_bcd;
+#  endif
+
+#endif  // ZMIJ_USE_SSE
+}
+
 
 // Converts a significand to decimal digits, removing trailing zeros. value has
 // up to 17 decimal digits (16-17 for normals) for double (num_bits == 64) and

--- a/zmij.cc
+++ b/zmij.cc
@@ -825,13 +825,17 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   const auto* c = &sse_consts;
   ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
 
+#   if ZMIJ_USE_SSE4_1
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
-  auto unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
-#   if ZMIJ_USE_SSE4_1
+  uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
   return {bswap64(unshuffled_bcd), count_trailing_nonzeros(bswap64(unshuffled_bcd))};
 #    else
-  return {unshuffled_bcd, count_trailing_nonzeros(unshuffled_bcd)};
+  // Ensure correct order of output.
+  uint64_t abcd_efgh =
+      (uint64_t(abcdefgh) << 32) - uint64_t((10000ull << 32) - 1) * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
+  uint64_t bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
+  return {bcd, count_trailing_nonzeros(bcd)};
 #    endif
 #  else // ZMIJ_USE_NEON
   const auto* c = &neon_consts;

--- a/zmij.cc
+++ b/zmij.cc
@@ -667,6 +667,7 @@ alignas(64) constexpr struct sse_constants {
 
 using m128ptr = const __m128i*;
 
+// Converts four numbers < 10000, one in each 32bit lane, to BCD digits.
 ZMIJ_INLINE auto to_digits_4x4digits(__m128i y, const sse_constants& c) noexcept
   -> __m128i {
   const __m128i div100 = _mm_load_si128(m128ptr(&c.div100));
@@ -724,19 +725,20 @@ alignas(64) static constexpr struct neon_constants {
   int16x8 multipliers16 = {0xce0, neg10};
 } neon_consts;
 
-ZMIJ_INLINE auto to_digits_4x4digits(int32x4_t ddee_bbcc_hhii_ffgg, const neon_constants* c) noexcept
+// Converts four numbers < 10000, one in each 32bit lane, to BCD digits.
+ZMIJ_INLINE auto to_digits_4x4digits(int32x4_t ddee_bbcc_hhii_ffgg, const neon_constants& c) noexcept
   -> uint8x16_t {
   // Compiler barrier, or clang breaks the subsequent MLA into UADDW + MUL.
   ZMIJ_ASM(("" : "+w"(ddee_bbcc_hhii_ffgg)));
 
   int32x4_t dd_bb_hh_ff =
-      vqdmulhq_n_s32(ddee_bbcc_hhii_ffgg, c->multipliers32[2]);
+      vqdmulhq_n_s32(ddee_bbcc_hhii_ffgg, c.multipliers32[2]);
   int16x8_t ee_dd_cc_bb_ii_hh_gg_ff = vreinterpretq_s16_s32(
-      vmlaq_n_s32(ddee_bbcc_hhii_ffgg, dd_bb_hh_ff, c->multipliers32[3]));
+      vmlaq_n_s32(ddee_bbcc_hhii_ffgg, dd_bb_hh_ff, c.multipliers32[3]));
   int16x8_t high_10s =
-      vqdmulhq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, c->multipliers16[0]);
+      vqdmulhq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, c.multipliers16[0]);
   return vreinterpretq_u8_s16(
-      vmlaq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, high_10s, c->multipliers16[1]));
+      vmlaq_n_s16(ee_dd_cc_bb_ii_hh_gg_ff, high_10s, c.multipliers16[1]));
 }
 
 // When reverse_hi_lo is true, the two 8-digit halves are returned in reversed
@@ -776,7 +778,7 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
   int32x4_t ddee_bbcc_hhii_ffgg = vreinterpretq_s32_u32(
       vshll_n_u16(vreinterpret_u16_s32(ddee_bbcc_hhii_ffgg_32), 0));
 
-  return to_digits_4x4digits(ddee_bbcc_hhii_ffgg, c);
+  return to_digits_4x4digits(ddee_bbcc_hhii_ffgg, *c);
 }
 #endif
 
@@ -846,7 +848,7 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   uint64_t abcd_efgh_64 =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   int32x4_t abcd_efgh = vcombine_s32(vreinterpret_s32_u64(vcreate_u64(abcd_efgh_64)), vdup_n_s32(0));
-  uint8x16_t digits_128 = to_digits_4x4digits(abcd_efgh, c);
+  uint8x16_t digits_128 = to_digits_4x4digits(abcd_efgh, *c);
   uint8x8_t digits = vget_low_u8(digits_128);
   uint64_t result = vget_lane_u64(vreinterpret_u64_u8(vrev64_u8(digits)), 0);
   return { result, count_trailing_nonzeros(result) };

--- a/zmij.cc
+++ b/zmij.cc
@@ -826,7 +826,7 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   const auto* c = &sse_consts;
   ZMIJ_ASM(("" : "+r"(c)));  // Load constants from memory.
 
-# if ZMIJ_USE_SSE4_1
+#  if ZMIJ_USE_SSE4_1
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));

--- a/zmij.cc
+++ b/zmij.cc
@@ -782,22 +782,6 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value) -> uint8x16_t {
 }
 #endif
 
-template <int num_bits> struct dec_digits {
-  uint64_t digits;
-  int num_digits;
-};
-
-template <> struct dec_digits<64> {
-#if ZMIJ_USE_NEON
-  uint16x8_t digits;
-#elif ZMIJ_USE_SSE
-  __m128i digits;
-#else
-  uint128 digits;
-#endif
-  int num_digits;
-};
-
 struct bcd_result {
   uint64_t bcd;
   int len;
@@ -854,6 +838,21 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
 #endif  // ZMIJ_USE_SSE
 }
 
+template <int num_bits> struct dec_digits {
+  uint64_t digits;
+  int num_digits;
+};
+
+template <> struct dec_digits<64> {
+#if ZMIJ_USE_NEON
+  uint16x8_t digits;
+#elif ZMIJ_USE_SSE
+  __m128i digits;
+#else
+  uint128 digits;
+#endif
+  int num_digits;
+};
 
 // Converts a significand to decimal digits, removing trailing zeros. value has
 // up to 17 decimal digits (16-17 for normals) for double (num_bits == 64) and

--- a/zmij.cc
+++ b/zmij.cc
@@ -648,8 +648,6 @@ alignas(64) constexpr struct sse_constants {
            u64(d) << 24 | u64(c) << 16 | u64(b) << +8 | u64(a);
   }
 
-  uint128 div10k = splat64(div10k_sig);
-  uint128 neg10k = splat64(::neg10k);
   uint128 div100 = splat32(div100_sig);
   uint128 div10 = splat16((1 << 16) / 10 + 1);
 #  if ZMIJ_USE_SSE4_1
@@ -661,6 +659,8 @@ alignas(64) constexpr struct sse_constants {
   uint128 hundred = splat32(100);
   uint128 moddiv10 = splat16(10 * (1 << 8) - 1);
 #  endif  // ZMIJ_USE_SSE4_1
+  uint128 div10k = splat64(div10k_sig);
+  uint128 neg10k = splat64(::neg10k);
   uint128 zeros = splat64(::zeros);
 } sse_consts;
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -829,7 +829,7 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
-  int len = unshuffled_bcd ? (64 - ctz(unshuffled_bcd)) / 8 : 0;
+  int len = unshuffled_bcd ? (71 - ctz(unshuffled_bcd)) / 8 : 0;
   return {bswap64(unshuffled_bcd), len};
 #    else
   // Ensure correct order of output.

--- a/zmij.cc
+++ b/zmij.cc
@@ -865,10 +865,10 @@ ZMIJ_INLINE auto to_digits(char* buffer, uint64_t value,
   // Digits/pairs of digits are denoted by letters: value = bbccddeeffgghhii.
   uint32_t bbccddee = uint32_t(value / 100'000'000);
   uint32_t ffgghhii = uint32_t(value % 100'000'000);
-  auto [hi, len_hi] = to_bcd8(bbccddee);
-  if (ffgghhii == 0) return {{hi + zeros, zeros}, len_hi};
-  auto [lo, len_lo] = to_bcd8(ffgghhii);
-  return {{hi + zeros, lo + zeros}, 8 + len_lo};
+  auto hi = to_bcd8(bbccddee);
+  if (ffgghhii == 0) return {{hi.bcd + zeros, zeros}, hi.len};
+  auto lo = to_bcd8(ffgghhii);
+  return {{hi.bcd + zeros, lo.bcd + zeros}, 8 + lo.len};
 #elif ZMIJ_USE_NEON
   auto unshuffled_digits = to_unshuffled_digits(value);
   uint8x16_t digits = vrev64q_u8(unshuffled_digits);
@@ -912,8 +912,8 @@ template <>
 ZMIJ_INLINE auto to_digits<32>(char* buffer, uint64_t value,
                                bool extra_digit) noexcept -> dec_digits<32> {
   write_if(buffer, value / 100'000'000, extra_digit);
-  auto [bcd, len] = to_bcd8(value % 100'000'000);
-  return {bcd + zeros, len};
+  auto result = to_bcd8(value % 100'000'000);
+  return {result.bcd + zeros, result.len};
 }
 
 #if ZMIJ_USE_SIMD_SHUFFLE

--- a/zmij.cc
+++ b/zmij.cc
@@ -829,7 +829,8 @@ auto to_bcd8(uint32_t abcdefgh) noexcept -> bcd_result {
   uint64_t abcd_efgh =
       abcdefgh + neg10k * ((uint64_t(abcdefgh) * div10k_sig) >> div10k_exp);
   uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_digits_4x4digits(_mm_set_epi64x(0, abcd_efgh), *c));
-  return {bswap64(unshuffled_bcd), count_trailing_nonzeros(bswap64(unshuffled_bcd))};
+  int len = unshuffled_bcd ? (64 - ctz(unshuffled_bcd)) / 8 : 0;
+  return {bswap64(unshuffled_bcd), len};
 #    else
   // Ensure correct order of output.
   uint64_t abcd_efgh =


### PR DESCRIPTION
This adds a SIMD implementation of `to_bcd8`, i.e. float->bcd conversion, addressing #99 

In order to share code with the double implementation, this splits the NEON and x64 SIMD codes into the parts that deal with 8-digit numbers (shared between `float` and `double`) and the part that deals with 16 digits. I also changed `to_bcd8`'s interface to return the length as it is significantly faster if the length in the SSE4.1 version is evaluated before `bswap`, likely because of the shorter dependency chain this creates.

Timings are taken with @Antares0982's benchmark which measures numbers which are output in fixed format, which means a significant amount of postprocessing to place the decimal point, and it can thus show an absolute speed increase, but yhe relative one has to be taken with a grain of salt.

On my M5 notebook it goes from 5.1ns/float to 4.7. On my AMD Ryzen from 8.9ns/float to 8.3 (SSE4.1) or 8.5 (SSE2).

There are some unexplored optimization opportunities, in no particular order:
- use 64bit SIMD on Neon (would save filling the upper 64bit lane, and maybe some energy)
- add '0' inside the SIMD path, this would maybe enable writing to memory directly from the SIMD path
- if we add the '0' and write to memory, the SSE shuffle is more attractive than bswap, and could be explored
- instead of the magic algebra in the SSE2 path to fill 64bit lanes in the correct order, fill in 32bit lanes with the simpler { x / 10k, x - x / 10k, 0, 0 }
- optimize the fixed path to insert the point in SSE (BTW I tried separating the first two digits instead of only the first before doing the SIMD thing in order to create space for the point: it was faster, but that may be due to wrong algebra because in my quick attempt I couldn't make it work correctly)