### PR TITLE
Add CMake Threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,9 @@ project(zmij CXX)
 
 set(ZMIJ_STANDARD cxx_std_14)
 
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
-
 add_library(zmij zmij.cc zmij.h)
 target_include_directories(zmij PUBLIC .)
 target_compile_features(zmij PRIVATE ${ZMIJ_STANDARD})
-target_link_libraries(zmij Threads::Threads)
 
 add_executable(example example.cc)
 target_link_libraries(example zmij)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,13 @@ project(zmij CXX)
 
 set(ZMIJ_STANDARD cxx_std_14)
 
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
+
 add_library(zmij zmij.cc zmij.h)
 target_include_directories(zmij PUBLIC .)
 target_compile_features(zmij PRIVATE ${ZMIJ_STANDARD})
+target_link_libraries(zmij Threads::Threads)
 
 add_executable(example example.cc)
 target_link_libraries(example zmij)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,9 +39,13 @@ target_sources(zmij-optimize-size-test PRIVATE pow10-test.cc)
 
 set(ZMIJ_CHECK_STANDARD cxx_std_20)
 
+
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
 add_library(fmt fmt/format.cc)
 target_compile_options(fmt PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 target_include_directories(fmt PUBLIC .)
+target_link_libraries(fmt Threads::Threads)
 
 add_executable(float-check float-check.cc)
 target_compile_features(float-check PRIVATE ${ZMIJ_CHECK_STANDARD})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,12 +39,11 @@ target_sources(zmij-optimize-size-test PRIVATE pow10-test.cc)
 
 set(ZMIJ_CHECK_STANDARD cxx_std_20)
 
-
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
 add_library(fmt fmt/format.cc)
 target_compile_options(fmt PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 target_include_directories(fmt PUBLIC .)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
 target_link_libraries(fmt Threads::Threads)
 
 add_executable(float-check float-check.cc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,7 +42,6 @@ set(ZMIJ_CHECK_STANDARD cxx_std_20)
 add_library(fmt fmt/format.cc)
 target_compile_options(fmt PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 target_include_directories(fmt PUBLIC .)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
 target_link_libraries(fmt Threads::Threads)
 


### PR DESCRIPTION
Hello,

zmij failed to link using GCC15.2 due to:

```
/software/system/gcc/15.2/bin/g++ -flto=auto -fno-fat-lto-objects  test/CMakeFiles/double-check.dir/double-check.cc.o -o test/double-check  test/libfmt.a && :
/tmp/k1078535/ccERVkvb.ltrans0.ltrans.o: In function `std::thread::_M_thread_deps_never_run()':
<artificial>:(.text+0x319): undefined reference to `pthread_create'
<artificial>:(.text+0x31e): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
```

I am not entirely sure what `std::thread::_M_thread_deps_never_run()` does. It was simple enough to add the usual CMake incantations to get `-pthread` where needed.