### PR TITLE
Scalars should not affect memory layout

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -145,6 +145,17 @@ static_assert(!ZMIJ_USE_SSE4_1 || ZMIJ_USE_SSE);
 #  define ZMIJ_ASM(x)
 #endif
 
+// Used to declare struct members that should live in memory for ARM64 but should be
+// implemented as immediates in the x64 assembly.
+#ifndef ZMIJ_CONST_SPECS
+#  if ZMIJ_AARCH64
+#    define ZMIJ_CONST_SPECS
+#  else
+#    define ZMIJ_CONST_SPECS static constexpr
+#  endif
+#endif
+
+
 namespace {
 
 #ifdef __cpp_lib_is_constant_evaluated
@@ -645,15 +656,9 @@ alignas(64) constexpr struct constants {
            u64(d) << 24 | u64(c) << 16 | u64(b) << +8 | u64(a);
   }
 
-#if defined(__ARM_NEON) || defined(_M_ARM64)
-  uint64_t threshold = 1e15;
+  ZMIJ_CONST_SPECS uint64_t threshold = 1e15;
   // +6 is needed for boundary cases found by verify.py.
-  uint64_t biased_half = (uint64_t(1) << 63) + 6;
-#else
-  static constexpr uint64_t threshold = 1e15;
-  // +6 is needed for boundary cases found by verify.py.
-  static constexpr uint64_t biased_half = (uint64_t(1) << 63) + 6;
-#endif
+  ZMIJ_CONST_SPECS uint64_t biased_half = (uint64_t(1) << 63) + 6;
 
 #if ZMIJ_USE_NEON
   static constexpr int32_t neg10k = -10000 + 0x10000;

--- a/zmij.cc
+++ b/zmij.cc
@@ -645,9 +645,15 @@ alignas(64) constexpr struct constants {
            u64(d) << 24 | u64(c) << 16 | u64(b) << +8 | u64(a);
   }
 
+#if defined(__ARM_NEON) || defined(_M_ARM64)
   uint64_t threshold = 1e15;
   // +6 is needed for boundary cases found by verify.py.
   uint64_t biased_half = (uint64_t(1) << 63) + 6;
+#else
+  static constexpr uint64_t threshold = 1e15;
+  // +6 is needed for boundary cases found by verify.py.
+  static constexpr uint64_t biased_half = (uint64_t(1) << 63) + 6;
+#endif
 
 #if ZMIJ_USE_NEON
   static constexpr int32_t neg10k = -10000 + 0x10000;


### PR DESCRIPTION
A recent change reorganized the constants and added two scalars at the top of the struct
```
  uint64_t threshold = 1e15;
  // +6 is needed for boundary cases found by verify.py.
  uint64_t biased_half = (uint64_t(1) << 63) + 6;
```
This is a pessimizing change. Now the constants for SSE `float` (`double`) conversion are spread out over 2 (3) cachelines instead of 1 (2).

The assembly of the SSE part with that change looks like this:
```
        pmuludq xmm1, XMMWORD PTR [r10+96]
        psrlq   xmm1, 40
        pmuludq xmm1, XMMWORD PTR [r10+112]
        paddq   xmm0, xmm1
        movdqa  xmm1, xmm0
        pmulhuw xmm1, XMMWORD PTR [r10+16]
        psrld   xmm1, 3
        pmulld  xmm1, XMMWORD PTR [r10+48]
        paddq   xmm0, xmm1
        movdqa  xmm1, xmm0
        pmulhuw xmm1, XMMWORD PTR [r10+32]
        pmullw  xmm1, XMMWORD PTR [r10+64]
        paddw   xmm0, xmm1
        movdqa  xmm1, xmm0
        pshufb  xmm1, XMMWORD PTR [r10+90]
        por     xmm1, XMMWORD PTR [r10+128]
        mov     BYTE PTR [rax+16], bl
        movups  XMMWORD PTR [rax], xmm1
```
and after the patch in this PR
```
        pmuludq xmm1, XMMWORD PTR [r10+80]
        psrlq   xmm1, 40
        pmuludq xmm1, XMMWORD PTR [r10+96]
        paddq   xmm0, xmm1
        movdqa  xmm1, xmm0
        pmulhuw xmm1, XMMWORD PTR [r10]
        psrld   xmm1, 3
        pmulld  xmm1, XMMWORD PTR [r10+32]
        paddq   xmm0, xmm1
        movdqa  xmm1, xmm0
        pmulhuw xmm1, XMMWORD PTR [r10+16]
        pmullw  xmm1, XMMWORD PTR [r10+48]
        paddw   xmm0, xmm1
        movdqa  xmm1, xmm0
        pshufb  xmm1, XMMWORD PTR [r10+64]
        por     xmm1, XMMWORD PTR [r10+112]
        mov     BYTE PTR [rax+16], bl
        movups  XMMWORD PTR [rax], xmm1
```
(the difference are the offsets where the constants are loaded from)

What is insane is the performance impact: this saves 0.5-1ns on my Tiger Lake laptop.
before: 29.17ns (28.34ns - 32.11ns) noisy
after:  28.43ns (27.27ns - 32.62ns) noisy

I have a hard time believing this, but it is entirely reproducible.

An aside: I noticed this because I realised that I could save one constant in the following way -- but then found the offsets suspiciously large --: replace
```
 uint128 bswap = uint128{pack8(15, 14, 13, 12, 11, 10, 9, 8),
                          pack8(7, 6, 5, 4, 3, 2, 1, 0)};
```
with
```
 uint128 bswap = uint128{pack8(15, 14, 13, 12, 11, 10, '9' , '8'),
                          pack8('7', '6', '5', '4', '3', '2', '1', '0')};
```
Then we can write instead of
```
auto bcd = _mm_shuffle_epi8(unshuffled_bcd, bswap);  // SSSE3
...
return {_mm_or_si128(bcd, zeros), len};
```
the alternative that doesn't need `zeros`
```
auto bcd = _mm_shuffle_epi8(unshuffled_bcd, bswap);  // SSSE3
...
return {_mm_shuffle_epi8(_mm_shuffle_epi8(bswap, bswap), bcd), len};
```
I'll see myself out now.