### PR TITLE
SSE improvements

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -901,21 +901,25 @@ ZMIJ_INLINE auto to_digits(uint64_t value, bool extra_digit,
   const __m128i zeros = _mm_load_si128(m128ptr(&c.zeros));
   auto unshuffled_bcd = to_unshuffled_digits(abbccddee, ffgghhii, c);
 #  if ZMIJ_USE_SSE4_1
+  // The length is determined from the number of trailing zeros which are
+  // in the low bits before the bswap.
+  __m128i mask128 = _mm_cmpgt_epi8(unshuffled_bcd, _mm_setzero_si128());
+  uint64_t mask = _mm_movemask_epi8(mask128);
+  int len = 16 - ctz(mask | (1 << 16));
+
   const __m128i bswap = _mm_load_si128(m128ptr(&c.bswap));
   auto bcd = _mm_shuffle_epi8(unshuffled_bcd, bswap);  // SSSE3
-#  else
+  return {_mm_or_si128(bcd, zeros), len};
+#  else // ZMIJ_USE_SSE4_1
   auto bcd = _mm_shuffle_epi32(unshuffled_bcd, _MM_SHUFFLE(0, 1, 2, 3));
-#  endif
-
-  // Count leading zeros.
+  
+  // The length is determined from the number of trailing zeros which are
+  // in the high bits.
   __m128i mask128 = _mm_cmpgt_epi8(bcd, _mm_setzero_si128());
   uint64_t mask = _mm_movemask_epi8(mask128);
-#  if defined(__LZCNT__) && !defined(ZMIJ_NO_BUILTINS)
-  int len = 32 - _lzcnt_u32(mask);
-#  else
   int len = 63 - clz((mask << 1) | 1);
-#  endif
   return {_mm_or_si128(bcd, zeros), len};
+#  endif // !ZMIJ_USE_SSE4_1
 #endif  // ZMIJ_USE_SSE
 }
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -756,6 +756,7 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint64_t value, const constants& c)
 using m128ptr = const __m128i*;
 
 // Converts four numbers < 10000, one in each 32bit lane, to BCD digits.
+// Digits in each 32bit lane will be in order for SSE2, reversed for SSE4.1.
 ZMIJ_INLINE auto to_bcd_4x4(__m128i y, const constants& c) noexcept -> __m128i {
   const __m128i div100 = _mm_load_si128(m128ptr(&c.div100));
   const __m128i div10 = _mm_load_si128(m128ptr(&c.div10));
@@ -780,10 +781,15 @@ ZMIJ_INLINE auto to_bcd_4x4(__m128i y, const constants& c) noexcept -> __m128i {
 #  endif  // ZMIJ_USE_SSE4_1
 }
 
+struct bcd_2x8_result {
+  __m128i bcd;
+  int len;
+};
+
 // SSE parallel version of to_bcd8: converts bbccddee and ffgghhii into
-// individual BCD digits in SIMD lane order (caller must shuffle).
-ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
-                                      const constants& c) noexcept -> __m128i {
+// individual BCD digits.  SSE4.1 result will be in reverse order.
+ZMIJ_INLINE auto to_bcd_2x8(uint32_t bbccddee, uint32_t ffgghhii,
+                            const constants& c) noexcept -> bcd_2x8_result {
   const __m128i div10k = _mm_load_si128(m128ptr(&c.div10k));
   const __m128i neg10k = _mm_load_si128(m128ptr(&c.neg10k));
   __m128i x = _mm_set_epi64x(bbccddee, ffgghhii);
@@ -795,7 +801,28 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
     // Shuffle to ensure correctly ordered result from SSE2 path.
     y = _mm_shuffle_epi32(y, _MM_SHUFFLE(0, 1, 2, 3));
   }
-  return to_bcd_4x4(y, c);
+
+  __m128i bcdx4 = to_bcd_4x4(y, c);
+#  if ZMIJ_USE_SSE4_1
+  // The length is determined from the number of trailing zeros which are
+  // in the low bits before bswap.
+  __m128i mask128 = _mm_cmpgt_epi8(bcdx4, _mm_setzero_si128());
+  uint64_t mask = _mm_movemask_epi8(mask128);
+  int len = 16 - ctz(mask | (1 << 16));
+
+  const __m128i bswap = _mm_load_si128(m128ptr(&c.bswap));
+  auto bcd = _mm_shuffle_epi8(bcdx4, bswap);  // SSSE3
+#  else // ZMIJ_USE_SSE4_1
+  auto bcd = bcdx4; // Output is already in final order.
+
+  // The length is determined from the number of trailing zeros which are
+  // in the high bits.
+  __m128i mask128 = _mm_cmpgt_epi8(bcd, _mm_setzero_si128());
+  uint64_t mask = _mm_movemask_epi8(mask128);
+  int len = 63 - clz((mask << 1) | 1);
+#  endif // !ZMIJ_USE_SSE4_1
+
+  return {bcd, len};
 }
 
 #endif  // ZMIJ_USE_SSE
@@ -903,28 +930,10 @@ ZMIJ_INLINE auto to_digits(uint64_t value, bool extra_digit,
   uint32_t abbccddee = uint32_t(value / 100'000'000);
   uint32_t ffgghhii = uint32_t(value % 100'000'000);
 
+  auto result = to_bcd_2x8(abbccddee, ffgghhii, c);
+
   const __m128i zeros = _mm_load_si128(m128ptr(&c.zeros));
-  auto unshuffled_bcd = to_unshuffled_digits(abbccddee, ffgghhii, c);
-#  if ZMIJ_USE_SSE4_1
-  // The length is determined from the number of trailing zeros which are
-  // in the low bits before the bswap.
-  __m128i mask128 = _mm_cmpgt_epi8(unshuffled_bcd, _mm_setzero_si128());
-  uint64_t mask = _mm_movemask_epi8(mask128);
-  int len = 16 - ctz(mask | (1 << 16));
-
-  const __m128i bswap = _mm_load_si128(m128ptr(&c.bswap));
-  auto bcd = _mm_shuffle_epi8(unshuffled_bcd, bswap);  // SSSE3
-  return {_mm_or_si128(bcd, zeros), len};
-#  else // ZMIJ_USE_SSE4_1
-  auto bcd = unshuffled_bcd; // Output is already in final order.
-
-  // The length is determined from the number of trailing zeros which are
-  // in the high bits.
-  __m128i mask128 = _mm_cmpgt_epi8(bcd, _mm_setzero_si128());
-  uint64_t mask = _mm_movemask_epi8(mask128);
-  int len = 63 - clz((mask << 1) | 1);
-  return {_mm_or_si128(bcd, zeros), len};
-#  endif // !ZMIJ_USE_SSE4_1
+  return {_mm_or_si128(result.bcd, zeros), result.len};
 #endif  // ZMIJ_USE_SSE
 }
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -790,6 +790,11 @@ ZMIJ_INLINE auto to_unshuffled_digits(uint32_t bbccddee, uint32_t ffgghhii,
   __m128i y = _mm_add_epi64(
       x, _mm_mul_epu32(neg10k,
                        _mm_srli_epi64(_mm_mul_epu32(x, div10k), div10k_exp)));
+
+  if (!ZMIJ_USE_SSE4_1) {
+    // Shuffle to ensure correctly ordered result from SSE2 path.
+    y = _mm_shuffle_epi32(y, _MM_SHUFFLE(0, 1, 2, 3));
+  }
   return to_bcd_4x4(y, c);
 }
 
@@ -911,8 +916,8 @@ ZMIJ_INLINE auto to_digits(uint64_t value, bool extra_digit,
   auto bcd = _mm_shuffle_epi8(unshuffled_bcd, bswap);  // SSSE3
   return {_mm_or_si128(bcd, zeros), len};
 #  else // ZMIJ_USE_SSE4_1
-  auto bcd = _mm_shuffle_epi32(unshuffled_bcd, _MM_SHUFFLE(0, 1, 2, 3));
-  
+  auto bcd = unshuffled_bcd; // Output is already in final order.
+
   // The length is determined from the number of trailing zeros which are
   // in the high bits.
   __m128i mask128 = _mm_cmpgt_epi8(bcd, _mm_setzero_si128());


### PR DESCRIPTION
This patch combines a number of improvements to the SSE code, but only one has measurable performance impact.

Like for the float path, it makes sense to evaluate the output length before BSWAP in the SSE4.1 path.  It also simplifies the insertion of the guard bit.  This is a significant performance gain on my Zen4 (8.1ns -> 7.7ns). To my surprise it is performance neutral on my Tiger Lake laptop. I removed the mention of LZCNT because it is a microarchitecture v3 instruction which now only appears on the microarchitecture v1 path. This is the first patch.

The second patch just makes the code clearer IMO and is performance neutral, but since it changes the sequence of operations I kept it separate: in the SSE2 code, the digits for each 32bit limb are evaluated in the correct order. Currently we shuffle the 32bit lanes at the end to obtain the correct order, but it seems structurally cleaner to shuffle when actually preparing the 32bit lanes.

The third patch reorganizes the SSE code somewhat. Given the previous patch only one of the two alternatives is actually shuffled, and so I wanted to make the name less confusing and ended up, well, shuffling the code around somewhat. Again, performance neutral, the code performs exactly the same operations in the same order.