### PR TITLE
Shuffle less for SSE4.1

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -1300,11 +1300,11 @@ auto write(Float value, char* buffer) noexcept -> char* {
 
   // Write significand/fixed.
   char* start = buffer;
-  auto dig = to_digits<traits::num_bits>(dec.sig, *d);
   constexpr int bcd_size = traits::num_bits == 64 ? 16 : 8;
   if (dec_exp >= traits::min_fixed_dec_exp &&
       dec_exp <= traits::max_fixed_dec_exp) {
     memcpy(start, &zeros, 8);  // For dec_exp < 0.
+    auto dig = to_digits<traits::num_bits>(dec.sig, *d);
     char last_digit = '0' + (-has_last_digit & dec.last_digit);
     int num_digits = select(has_last_digit, bcd_size, dig.num_digits - 1);
 
@@ -1317,18 +1317,18 @@ auto write(Float value, char* buffer) noexcept -> char* {
     buffer += layout.start_pos;
 #if ZMIJ_USE_SSE4_1
     if (bcd_size == 16) {
-      // dig.digits is uint64_t for float, alias as __m128i to avoid a compiler error.
-      auto& digits = reinterpret_cast<const __m128i&>(dig.digits);
       // Assemble the digit string (minus the last_digit and, for has_extra_digit
       // == 1, BCD[15]) in a single SIMD register and store it in one go.
       __m128i tbl = _mm_load_si128(m128ptr(&layout.shuffle[has_extra_digit]));
-      __m128i out = _mm_shuffle_epi8(digits, tbl);
-      memcpy(buffer, &out, bcd_size);
+      // dig.digits is uint64_t for float, alias as __m128i to avoid a compiler error.
+      auto& digits = reinterpret_cast<const __m128i&>(dig.digits);
       // For has_extra_digit == 1 with 0 <= dec_exp <= 14 the BCD[15] byte falls
       // outside the vector at buffer[16]; write it unconditionally.  In the
       // other cases (dec_exp == 15, dec_exp < 0, or has_extra_digit == 0) it's
       // either already in the vector or overwritten below by '.' / last_digit.
       buffer[bcd_size] = (char)_mm_extract_epi8(digits, 15);
+      __m128i out = _mm_shuffle_epi8(digits, tbl);
+      memcpy(buffer, &out, bcd_size);
       start[layout.point_pos] = '.';
       buffer[layout.last_digit_pos[has_extra_digit]] = last_digit;
       return buffer + layout.end_pos[num_digits + has_extra_digit - 1];
@@ -1341,6 +1341,7 @@ auto write(Float value, char* buffer) noexcept -> char* {
     start[point_pos] = '.';
     return buffer + layout.end_pos[num_digits + has_extra_digit - 1];
   }
+  auto dig = to_digits<traits::num_bits>(dec.sig, *d);
   if (traits::num_bits == 32 && exp_float_shuffle_table::enable) {
     uint64_t exp_data = d->exp_strings.data[dec_exp + exp_string_table::offset];
     return write_exp_float_simd(buffer, dig, dec.last_digit, has_last_digit,

--- a/zmij.cc
+++ b/zmij.cc
@@ -610,12 +610,30 @@ struct fixed_layout_table {
       traits::max_fixed_dec_exp - traits::min_fixed_dec_exp + 1;
 
   // On AArch64, align entry to 32 bytes so indexing uses `lsl #5` not `umaddl`.
-  struct alignas(ZMIJ_AARCH64 && !ZMIJ_OPTIMIZE_SIZE ? 32 : 1) entry {
-    // Byte offset past leading "0.00..." before first significant digit.
+  // On x86 with SSE4.1, align entry to 64 bytes (one cache line) and put the
+  // 16-byte-aligned shuffle table at the back: the scalar fields and the
+  // shuffle for any single dec_exp then share one cache-line fill.
+  struct alignas(ZMIJ_AARCH64 && !ZMIJ_OPTIMIZE_SIZE ? 32
+                 : ZMIJ_USE_SSE4_1
+                    ? (ZMIJ_OPTIMIZE_SIZE ? 16 : 64) : 1) entry {
+#if ZMIJ_USE_SSE4_1
+    // pshufb shuffle table that places BCD bytes in their final output slots,
+    // with the byte at the decimal-point position (if any) set to a pshufb
+    // "zero" marker (high bit set).  Indexed by extra_digit.
+    //  Needs 16 byte alignment because of aligned load below.
+    alignas(16) unsigned char shuffle[2][16];
+#endif
+
+// Byte offset past leading "0.00..." before first significant digit.
     unsigned char start_pos;
     unsigned char point_pos;
     // Start position for shifting digits right by one to insert the point.
     unsigned char shift_pos;
+#if ZMIJ_USE_SSE4_1
+    // Buffer-relative position of the last_digit byte, indexed by has_extra_digit.
+    // Only used for bcd_size == 16 (doubles).
+    unsigned char last_digit_pos[2];
+#endif
     // Offset past the end of fixed-notation output, indexed by sig length - 1.
     unsigned char end_pos[traits::max_digits10];
   };
@@ -630,9 +648,37 @@ struct fixed_layout_table {
       e.point_pos = dec_exp >= 0 ? 1 + dec_exp : 1;
       e.shift_pos = e.point_pos + (dec_exp >= 0);
 
+#if ZMIJ_USE_SSE4_1
+      constexpr int bcd_size = 16;
+      for (int extra = 0; extra < 2; ++extra) {
+        int full_size = bcd_size + extra - 1;
+        e.last_digit_pos[extra] =
+            full_size + ((0 <= dec_exp) && (dec_exp < full_size));
+      }
+
+      // Build the shuffle tables.  to_digits returns natural-order BCD bytes
+      // (BCD[k] at register byte k).  For extra_digit == 1 the integer part
+      // is BCD[0..dec_exp]; for extra_digit == 0 the leading zero is dropped,
+      // so the integer part is BCD[1..dec_exp+1].  In both cases the decimal
+      // point sits at output byte 1 + dec_exp (when in [0, 14]) and is
+      // encoded as a pshufb zero-marker (high bit set).  For dec_exp == 15
+      // or dec_exp < 0 no point lives inside the vector and the entry is
+      // just identity with the extra_digit offset folded in.
+      int hole = (dec_exp >= 0 && dec_exp <= 14) ? 1 + dec_exp : 128;
+      for (int extra = 0; extra < 2; ++extra) {
+        int bcd_idx = !extra;
+        for (int i = 0; i < bcd_size; ++i) {
+          if (i == hole) {
+            e.shuffle[extra][i] = 0xFF;
+          } else {
+            e.shuffle[extra][i] = (unsigned char)bcd_idx++;
+          }
+        }
+      }
+#endif
+
       for (int n = 1; n <= traits::max_digits10; ++n) {
-        int end_pos = n;
-        if (dec_exp >= 0) end_pos = n > dec_exp + 1 ? n + 1 : dec_exp + 1;
+        int end_pos = dec_exp < 0 ? n : (n > dec_exp + 1 ? n + 1 : dec_exp + 1);
         e.end_pos[n - 1] = end_pos;
       }
     }
@@ -1260,7 +1306,7 @@ auto write(Float value, char* buffer) noexcept -> char* {
       dec_exp <= traits::max_fixed_dec_exp) {
     memcpy(start, &zeros, 8);  // For dec_exp < 0.
     char last_digit = '0' + (-has_last_digit & dec.last_digit);
-    int num_digits = has_last_digit ? bcd_size : dig.num_digits - 1;
+    int num_digits = select(has_last_digit, bcd_size, dig.num_digits - 1);
 
     // Materialize the base early so the entry address is `base + idx*32`;
     // otherwise Clang folds the offset in and adds a cycle to the idx chain.
@@ -1269,6 +1315,25 @@ auto write(Float value, char* buffer) noexcept -> char* {
 
     const auto& layout = fixed_layouts->get(dec_exp);
     buffer += layout.start_pos;
+#if ZMIJ_USE_SSE4_1
+    if (bcd_size == 16) {
+      // dig.digits is uint64_t for float, alias as __m128i to avoid a compiler error.
+      auto& digits = reinterpret_cast<const __m128i&>(dig.digits);
+      // Assemble the digit string (minus the last_digit and, for has_extra_digit
+      // == 1, BCD[15]) in a single SIMD register and store it in one go.
+      __m128i tbl = _mm_load_si128(m128ptr(&layout.shuffle[has_extra_digit]));
+      __m128i out = _mm_shuffle_epi8(digits, tbl);
+      memcpy(buffer, &out, bcd_size);
+      // For has_extra_digit == 1 with 0 <= dec_exp <= 14 the BCD[15] byte falls
+      // outside the vector at buffer[16]; write it unconditionally.  In the
+      // other cases (dec_exp == 15, dec_exp < 0, or has_extra_digit == 0) it's
+      // either already in the vector or overwritten below by '.' / last_digit.
+      buffer[bcd_size] = (char)_mm_extract_epi8(digits, 15);
+      start[layout.point_pos] = '.';
+      buffer[layout.last_digit_pos[has_extra_digit]] = last_digit;
+      return buffer + layout.end_pos[num_digits + has_extra_digit - 1];
+    }
+#endif
     write_digits(buffer, dig.digits, !has_extra_digit, *d);
     buffer[bcd_size + has_extra_digit - 1] = last_digit;
     unsigned point_pos = layout.point_pos;

--- a/zmij.cc
+++ b/zmij.cc
@@ -656,11 +656,11 @@ struct fixed_layout_table {
             full_size + ((0 <= dec_exp) && (dec_exp < full_size));
       }
 
-      // Build the shuffle tables.  to_digits returns natural-order BCD bytes
-      // (BCD[k] at register byte k).  For extra_digit == 1 the integer part
-      // is BCD[0..dec_exp]; for extra_digit == 0 the leading zero is dropped,
-      // so the integer part is BCD[1..dec_exp+1].  In both cases the decimal
-      // point sits at output byte 1 + dec_exp (when in [0, 14]) and is
+      // Build the shuffle tables.  to_digits returns bute-reversed BCD bytes.
+      // For extra_digit == 1 the integer part is BCD[15..15-dec_exp]; for
+      // extra_digit == 0 the leading zero is dropped, so the integer part
+      // is BCD[14..14-dec_exp].  In both cases the decimal point sits at
+      // output byte 1 + dec_exp (when in [0, 14]) and is
       // encoded as a pshufb zero-marker (high bit set).  For dec_exp == 15
       // or dec_exp < 0 no point lives inside the vector and the entry is
       // just identity with the extra_digit offset folded in.
@@ -671,7 +671,7 @@ struct fixed_layout_table {
           if (i == hole) {
             e.shuffle[extra][i] = 0xFF;
           } else {
-            e.shuffle[extra][i] = (unsigned char)bcd_idx++;
+            e.shuffle[extra][i] = 15 - (unsigned char)bcd_idx++;
           }
         }
       }
@@ -962,6 +962,9 @@ template <> struct dec_digits<64> {
   using digits_type = uint128;
 #endif
   digits_type digits;
+#if ZMIJ_USE_SSE4_1
+  digits_type digits_reversed;
+#endif
   int num_digits;
 };
 
@@ -1011,9 +1014,11 @@ ZMIJ_INLINE auto to_digits(uint64_t value, const data& d) noexcept
   // Trailing zeros are in the low bits for SSE4.1, the high bits for SSE2.
   int len = ZMIJ_USE_SSE4_1 ? 16 - ctz(mask) : 64 - clz(mask);
 #  if ZMIJ_USE_SSE4_1
-  bcd = _mm_shuffle_epi8(bcd, _mm_load_si128(m128ptr(&d.bswap)));  // SSSE3
-#  endif
+  bcd = _mm_or_si128(bcd, zeros);
+  return { _mm_shuffle_epi8(bcd, _mm_load_si128(m128ptr(&d.bswap))), bcd, len };
+#  else
   return {_mm_or_si128(bcd, zeros), len};
+#endif
 #endif  // ZMIJ_USE_SSE
 }
 
@@ -1320,15 +1325,16 @@ auto write(Float value, char* buffer) noexcept -> char* {
       // Assemble the digit string (minus the last_digit and, for has_extra_digit
       // == 1, BCD[15]) in a single SIMD register and store it in one go.
       __m128i tbl = _mm_load_si128(m128ptr(&layout.shuffle[has_extra_digit]));
-      // dig.digits is uint64_t for float, alias as __m128i to avoid a compiler error.
-      auto& digits = reinterpret_cast<const __m128i&>(dig.digits);
+      // Alias dig in order to avoid a compiler error when accessing the digits_reversed
+      // member which only exists for doubles.
+      auto& dig64 = reinterpret_cast<dec_digits<64>&>(dig);
       // For has_extra_digit == 1 with 0 <= dec_exp <= 14 the BCD[15] byte falls
       // outside the vector at buffer[16]; write it unconditionally.  In the
       // other cases (dec_exp == 15, dec_exp < 0, or has_extra_digit == 0) it's
       // either already in the vector or overwritten below by '.' / last_digit.
-      buffer[bcd_size] = (char)_mm_extract_epi8(digits, 15);
-      __m128i out = _mm_shuffle_epi8(digits, tbl);
-      memcpy(buffer, &out, bcd_size);
+      buffer[16] = (char)_mm_extract_epi8(dig64.digits_reversed, 0);
+      __m128i out = _mm_shuffle_epi8(dig64.digits_reversed, tbl);
+      memcpy(buffer, &out, 16);
       start[layout.point_pos] = '.';
       buffer[layout.last_digit_pos[has_extra_digit]] = last_digit;
       return buffer + layout.end_pos[num_digits + has_extra_digit - 1];


### PR DESCRIPTION
In the current code, we shuffle to reverse the byte order and we shuffle to shift the bits. This combines the two. It also replaces a slow `memmove` for the decimal digits with another shuffle + store, so that the data is never re-read from memory.

This is my first AI-assisted patch to zmij, and the AI's main task was to figure out the special cases when moving the writing of the last digit behind the shuffles. Previously, the last_digit only sometimes was part of the memmove and could thus end up in  a different position. The AI suggested to keep a table of where it goes, and so I did that. A table-free approach made the compiler add a branch and lose time.

The way I avoided to increase the table size for the various bswap + shift variations and thus messing up alignments or introducing padding is quite simple: what we want to do is to reverse the order and drop the first N digits, where N depends on whether its the integral part or the decimals, and it depends on the exponent. We don't care what is added in the end past the actual digits. So, it doesn't actually matter what the last few entries in the shuffler are, and so we just keep the same bswap shuffle table, read it at an offset and don't care what the entries at the end end up being. This only works because we reverse at the same time, so this cannot be carried to the NEON code.  The additional bytes are loaded from the same struct, so it's not uninitialized memory and ASAN is happy, but I'm not sure what the standard says about this. I don't think the SIMD memory access is in its scope. BTW I changed the type of `bswap` to `char *` in order to get simpler index algebra and less casts.

Finally, in order to keep everything branch-free, in the case of `dec_exp < 0` where no decimal point is inserted between the digits, the identical shuffle + store operation is simply repeated. This turned out to be measurably faster than conditionally jumping past it. Note that the zmij/canada benchmark, given Canada's geography, doesn't contain any numbers < 1, so I created a separate benchmark (not included) that uses random fixed numbers. To my surprise it was actually faster than the processing of the Canada data. A possible explanation is that it triggered the `last_digit` far less often but I didn't check this in detail.

On my Zen 4 this saves 5%, on my Tiger Lake it is performance neutral.

I also asked Claude to do try the same thing for NEON but none of the variations it tried came out faster than what is there right now.

ps I just saw that I didn't clean this up fully. Hence the non-squashed three-patch series with one unrelated change that I didn't mean to commit as part of this: I moved the `alignas(64)` annotation from the `static_data` declaration to the `struct data` declaration. The idea being that this way all the pointers that we use remember the alignment. Turns out the assembly with and without this change is the same on x64 https://godbolt.org/z/Mxz1fbKjY and ARM64 https://godbolt.org/z/ecnPzTWhK, but I think it's cleaner, so I'm not going to remove it right now even though it is unrelated.
