### PR TITLE
Rename select

### DIFF
--- a/zmij.c
+++ b/zmij.c
@@ -323,7 +323,7 @@ static ZMIJ_INLINE uint64_t div10(uint64_t x) {
 }
 
 // Returns true_value if condition != 0, else false_value, without branching.
-static ZMIJ_INLINE int64_t select(uint64_t condition, int64_t true_value,
+static ZMIJ_INLINE int64_t zmij_select(uint64_t condition, int64_t true_value,
                                   int64_t false_value) {
   // Clang can figure it out on its own.
   if (!ZMIJ_X86_64 || ZMIJ_CLANG) return condition ? true_value : false_value;


### PR DESCRIPTION
On my x86-64 Arch Linux system I get the following error when trying to integrate zmij with MoarVM:
```
3rdparty/zmij/zmij.c:326:28: error: conflicting types for ‘select’; have ‘int64_t(uint64_t,  int64_t,  int64_t)’ {aka ‘long int(long unsigned int,  long int,  long int)’}
  326 | static ZMIJ_INLINE int64_t select(uint64_t condition, int64_t true_value,
      |                            ^~~~~~
In file included from /usr/include/sys/types.h:179,
                 from /usr/include/stdlib.h:518,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/include/mm_malloc.h:27,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/include/xmmintrin.h:34,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/include/immintrin.h:31,
                 from 3rdparty/zmij/zmij.c:47:
/usr/include/sys/select.h:102:12: note: previous declaration of ‘select’ with type ‘int(int,  fd_set * restrict,  fd_set * restrict,  fd_set * restrict,  struct timeval * restrict)’
  102 | extern int select (int __nfds, fd_set *__restrict __readfds,
      |            ^~~~~~
```