### PR TITLE
Build float string inside SIMD register, gain 30%

### DIFF
--- a/zmij.cc
+++ b/zmij.cc
@@ -540,6 +540,79 @@ struct exp_string_table {
   }
 };
 
+// Shuffle masks for branchless float scientific-notation output. A single
+// pshufb assembles "<d>.<rest><e±xx>" from a source register holding the
+// unshuffled (LSD-first) ASCII digits in bytes 0..7, the exp string
+// in bytes 8..11, the decimal point (byte 12 = '.'), and the last_digit
+// (ASCII, byte 13). The shuffle indices reverse the byte order while
+// inserting the decimal point and placing the exponent after the last
+// non-zero digit.
+//
+// In unshuffled form: for extra_digit, MSD lives at byte 7 (LSD at 0);
+// for the leading-zero-padded case (no extra_digit), MSD is at byte 6
+// and byte 7 holds the padding '0'.
+//
+// After benchmnarking, the fastest way of indexing appears to be a flat
+// array with index = (num_digits - 1) * 4 + has_last_digit * 2 + extra_digit.
+struct scientific_float_mask_table {
+  static constexpr bool enable = ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON;
+
+  alignas(16) unsigned char masks[enable ? 32 * 16 : 1] = {};
+  unsigned char lengths[enable ? 32 : 1] = {};
+
+  constexpr auto get_index(int ndigits, int has_last, int has_extra_digit) const noexcept {
+    return (ndigits - 1) * 4 + has_last * 2 + has_extra_digit;
+  }
+
+  struct entry {
+    const unsigned char* mask;
+    unsigned char length;
+  };
+
+  constexpr auto get_entry(int ndigits, bool has_last, bool has_extra_digit) const noexcept {
+    auto idx = get_index(ndigits, has_last, has_extra_digit);
+    return entry{ &masks[idx * 16], lengths[idx] };
+  }
+
+  constexpr scientific_float_mask_table() {
+    if (!enable) return;
+    for (int ndigits = 1; ndigits <= 8; ++ndigits) {
+      for (int has_last = 0; has_last < 2; ++has_last) {
+        for (int extra_digit = 0; extra_digit < 2; ++extra_digit) {
+          int idx =  get_index(ndigits, has_last, extra_digit);
+          unsigned char* out = &masks[idx * 16];
+          for (int i = 0; i < 16; ++i) out[i] = 0x80;  // zero by default
+
+          // Position of the MSD in the LSD-first unshuffled byte order.
+          unsigned char msd_byte = extra_digit ? 7 : 6;
+          unsigned char length = 0;
+          if (has_last) {
+            // Always 8 BCD chars in the significand plus a last-digit char;
+            // for !extra_digit the leading '0' of the 8-digit padded BCD is shown.
+            out[length++] = msd_byte;
+            out[length++] = 13;  // '.'
+            for (int i = 0; i < (extra_digit ? 7 : 6); ++i)
+              out[length++] = msd_byte - 1 - i;
+            out[length++] = 12;  // last_digit
+          } else {
+            length = (extra_digit + ndigits == 2) ? 1 : extra_digit + ndigits;
+            out[0] = msd_byte;
+            if (length > 1) {
+              out[1] = 13;  // '.'
+              for (int i = 0; i < length - 2; ++i)
+                out[2 + i] = msd_byte - 1 - i;
+            }
+          }
+          // Exp string follows the significand.
+          for (unsigned char i = 0; i < 4; ++i)
+            out[length++] = 8 + i;
+          lengths[idx] = length;
+        }
+      }
+    }
+  }
+};
+
 // Per-decimal-exponent buffer layout for branchless fixed-notation output.
 // Each entry holds the byte positions of the leading zeros, decimal point,
 // and end of output, indexed by the decimal exponent (dec_exp).
@@ -688,6 +761,7 @@ struct data {
   exp_string_table exp_strings;
   alignas(64) pow10_significand_table pow10_significands;
   fixed_layout_table fixed_layouts;
+  scientific_float_mask_table scientific_float_masks;
 
   // Shuffle indices for SIMD digit shift. Offset 0 = identity, offset 1 =
   // shift left by 1 (drops the leading '0' of a 16-digit significand).
@@ -695,6 +769,7 @@ struct data {
                                      9, 10, 11, 12, 13, 14, 15, 0};
 };
 alignas(64) constexpr data static_data;
+
 
 #if ZMIJ_USE_NEON  // An optimized version for NEON by Dougall Johnson.
 
@@ -839,6 +914,23 @@ template <int num_bits> struct dec_digits {
   int num_digits;
 };
 
+// For float on SSE4.1/NEON we keep the unshuffled (LSD-first) numeric BCD
+// around so the scientific path can avoid the SIMD→gpr→bswap→SIMD roundtrip
+// needed to materialize `digits`.
+#if ZMIJ_USE_SSE4_1
+template <> struct dec_digits<32> {
+  uint64_t digits;
+  __m128i unshuffled;
+  int num_digits;
+};
+#elif ZMIJ_USE_NEON
+template <> struct dec_digits<32> {
+  uint64_t digits;
+  uint8x16_t unshuffled;
+  int num_digits;
+};
+#endif
+
 template <> struct dec_digits<64> {
 #if ZMIJ_USE_NEON
   using digits_type = uint16x8_t;
@@ -904,10 +996,35 @@ ZMIJ_INLINE auto to_digits(uint64_t value, const data& d) noexcept
 }
 
 template <>
-ZMIJ_INLINE auto to_digits<32>(uint64_t value, const data&) noexcept
+ZMIJ_INLINE auto to_digits<32>(uint64_t value,
+                               [[ZMIJ_MAYBE_UNUSED]] const data& d) noexcept
     -> dec_digits<32> {
+#if ZMIJ_USE_SSE4_1
+  // Inline to_bcd8's SSE4.1 body so we can return the unshuffled xmm too;
+  // the scientific-notation path uses it to skip the bswap-via-gpr.
+  uint64_t abcd_efgh =
+      value + neg10k * ((value * div10k_sig) >> div10k_exp);
+  __m128i bcd_xmm = to_bcd_4x4(_mm_set_epi64x(0, abcd_efgh), d);
+  uint64_t unshuffled_bcd = _mm_cvtsi128_si64(bcd_xmm);
+  int len = unshuffled_bcd ? 8 - ctz(unshuffled_bcd) / 8 : 0;
+  return {bswap64(unshuffled_bcd) + zeros, bcd_xmm, len};
+#elif ZMIJ_USE_NEON
+  // Inline to_bcd8's NEON body so we can return the unshuffled vector too;
+  // the scientific-notation path uses it to skip the simd->gpr->bswap->simd
+  // roundtrip needed to materialize `digits`.
+  uint64_t abcd_efgh =
+      value + neg10k * ((value * div10k_sig) >> div10k_exp);
+  int32x4_t input = vcombine_s32(
+      vreinterpret_s32_u64(vcreate_u64(abcd_efgh)), vdup_n_s32(0));
+  uint8x16_t unshuffled = to_bcd_4x4(input, d);
+  uint64_t unshuffled_bcd = vget_lane_u64(
+      vreinterpret_u64_u8(vget_low_u8(unshuffled)), 0);
+  int len = unshuffled_bcd ? 8 - ctz(unshuffled_bcd) / 8 : 0;
+  return {bswap64(unshuffled_bcd) + zeros, unshuffled, len};
+#else
   auto result = to_bcd8(value);
   return {result.bcd + zeros, result.len};
+#endif
 }
 
 // Writes `digits` to `buffer`, dropping the leading '0' when drop_leading_zero
@@ -937,6 +1054,56 @@ ZMIJ_INLINE void write_digits(char* buffer, uint64_t digits,
   memcpy(buffer, &digits, sizeof(digits));
   memmove(buffer, buffer + drop_leading_zero, sizeof(digits));
 }
+
+#if ZMIJ_USE_SSE4_1
+ZMIJ_INLINE auto write_scientific_float_simd(
+    char* buffer, const dec_digits<32>& dig, int last_digit_value,
+    bool has_last_digit, bool extra_digit, uint64_t exp_data,
+    const data& d) noexcept -> char* {
+  __m128i ascii = _mm_or_si128(dig.unshuffled,
+                               _mm_load_si128(m128ptr(&d.zeros)));
+  uint32_t prefix = (uint32_t('.') << 8) + uint32_t('0') + last_digit_value;
+  uint64_t hi_qword = (exp_data & 0xFFFFFFFFu) | (uint64_t(prefix) << 32);
+  __m128i src = _mm_insert_epi64(ascii, int64_t(hi_qword), 1);
+  auto m = d.scientific_float_masks.get_entry(dig.num_digits, has_last_digit, extra_digit);
+  __m128i mask = _mm_load_si128(m128ptr(m.mask));
+  __m128i out = _mm_shuffle_epi8(src, mask);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), out);
+  return buffer + m.length;
+}
+
+// Dummy overload so write<double> instantiates cleanly. The runtime
+// guard `traits::num_bits == 32` in `write` folds this call away.
+ZMIJ_INLINE auto write_scientific_float_simd(
+    char*, const dec_digits<64>&, int, bool, bool, uint64_t,
+    const data&) noexcept -> char* {
+  return nullptr;
+}
+#elif ZMIJ_USE_NEON
+ZMIJ_INLINE auto write_scientific_float_simd(
+    char* buffer, const dec_digits<32>& dig, int last_digit_value,
+    bool has_last_digit, bool extra_digit, uint64_t exp_data,
+    const data&) noexcept -> char* {
+  uint8x16_t ascii = vorrq_u8(dig.unshuffled, vdupq_n_u8('0'));
+  uint32_t prefix = (uint32_t('.') << 8) + uint32_t('0') + last_digit_value;
+  uint64_t hi_qword = (exp_data & 0xFFFFFFFFu) | (uint64_t(prefix) << 32);
+  uint8x16_t src = vreinterpretq_u8_u64(
+      vsetq_lane_u64(hi_qword, vreinterpretq_u64_u8(ascii), 1));
+
+  auto m = d.scientific_float_masks.get_entry(dig.num_digits, has_last_digit, extra_digit);
+  int idx = (dig.num_digits - 1) * 4 + int(has_last_digit + 2 * extra_digit);
+  uint8x16_t mask = vld1q_u8(m.mask);
+  uint8x16_t out = vqtbl1q_u8(src, mask);
+  vst1q_u8(reinterpret_cast<uint8_t*>(buffer), out);
+  return buffer + m.length;
+}
+
+ZMIJ_INLINE auto write_scientific_float_simd(
+    char*, const dec_digits<64>&, int, bool, bool, uint64_t,
+    const data&) noexcept -> char* {
+  return nullptr;
+}
+#endif
 
 struct to_decimal_result {
   long long sig;
@@ -1149,6 +1316,15 @@ auto write(Float value, char* buffer) noexcept -> char* {
     start[point_pos] = '.';
     return buffer + layout.end_pos[num_digits + extra_digit - 1];
   }
+#if ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON
+  if (traits::num_bits == 32 && exp_string_table::enable) {
+    uint64_t exp_data = d->exp_strings.data[dec_exp + exp_string_table::offset];
+    return write_scientific_float_simd(buffer, dig, dec.last_digit,
+                                       has_last_digit, extra_digit, exp_data,
+                                       *d);
+  }
+#endif
+
   buffer += extra_digit;
   memcpy(buffer, &dig.digits, bcd_size);
   buffer[bcd_size] = '0' + dec.last_digit;

--- a/zmij.cc
+++ b/zmij.cc
@@ -575,7 +575,7 @@ struct scientific_float_mask_table {
           unsigned char* out = &masks[idx * 16];
           for (int i = 0; i < 16; ++i) out[i] = 0x80;  // zero by default
 
-          // Position of the MSD in the LSD-first unshuffled byte order.
+          // Position of the most significant digit in the reversed input.
           unsigned char msd_byte = extra_digit ? 7 : 6;
           unsigned char length = 0;
           if (has_last) {
@@ -583,16 +583,16 @@ struct scientific_float_mask_table {
             // for !extra_digit the leading '0' of the 8-digit padded BCD is shown.
             out[length++] = msd_byte;
             out[length++] = 13;  // '.'
-            for (int i = 0; i < (extra_digit ? 7 : 6); ++i)
-              out[length++] = msd_byte - 1 - i;
+            for (int i = msd_byte - 1; i >= 0; --i)
+              out[length++] = i;
             out[length++] = 12;  // last_digit
           } else {
             length = (extra_digit + ndigits == 2) ? 1 : extra_digit + ndigits;
             out[0] = msd_byte;
             if (length > 1) {
               out[1] = 13;  // '.'
-              for (int i = 0; i < length - 2; ++i)
-                out[2 + i] = msd_byte - 1 - i;
+              for (int i = 2; i < length; ++i)
+                out[i] = msd_byte + 1 - i;
             }
           }
           // Exp string follows the significand.

--- a/zmij.cc
+++ b/zmij.cc
@@ -555,7 +555,7 @@ struct exp_string_table {
 // After benchmnarking, the fastest way of indexing appears to be a flat
 // array with index = (num_digits - 1) * 4 + has_last_digit * 2 + extra_digit.
 struct scientific_float_mask_table {
-  static constexpr bool enable = ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON;
+  static constexpr bool enable = (ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON) && exp_string_table::enable;
 
   alignas(16) unsigned char masks[enable ? 32 * 16 : 1] = {};
   unsigned char lengths[enable ? 32 : 1] = {};
@@ -1304,7 +1304,7 @@ auto write(Float value, char* buffer) noexcept -> char* {
     return buffer + layout.end_pos[num_digits + extra_digit - 1];
   }
 #if ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON
-  if (traits::num_bits == 32 && exp_string_table::enable) {
+  if (traits::num_bits == 32 && scientific_float_mask_table::enable) {
     uint64_t exp_data = d->exp_strings.data[dec_exp + exp_string_table::offset];
     return write_scientific_float_simd(buffer, dig, dec.last_digit,
                                        has_last_digit, extra_digit, exp_data,

--- a/zmij.cc
+++ b/zmij.cc
@@ -909,27 +909,24 @@ auto to_bcd8(uint64_t abcdefgh) noexcept -> bcd_result {
 #endif  // ZMIJ_USE_SSE
 }
 
-template <int num_bits> struct dec_digits {
-  uint64_t digits;
-  int num_digits;
-};
+template <int num_bits> struct dec_digits;
 
-// For float on SSE4.1/NEON we keep the unshuffled (LSD-first) numeric BCD
-// around so the scientific path can avoid the SIMD→gpr→bswap→SIMD roundtrip
-// needed to materialize `digits`.
+// For the SIMD paths with shuffle operations (SSE4.1, NEON) we
+// keep the byte-reversed ("unshuffled") SIMD result, as we use
+// it to put together the full string in the SIMD register for
+// output with exponents (scientific style).
+template <> struct dec_digits<32> {
 #if ZMIJ_USE_SSE4_1
-template <> struct dec_digits<32> {
-  uint64_t digits;
-  __m128i unshuffled;
-  int num_digits;
-};
+  using wide_type = __m128i;
 #elif ZMIJ_USE_NEON
-template <> struct dec_digits<32> {
+  using wide_type = uint8x16_t;
+#else
+  using wide_type = uint128; // unused
+#endif
   uint64_t digits;
-  uint8x16_t unshuffled;
+  wide_type unshuffled;
   int num_digits;
 };
-#endif
 
 template <> struct dec_digits<64> {
 #if ZMIJ_USE_NEON
@@ -1023,7 +1020,7 @@ ZMIJ_INLINE auto to_digits<32>(uint64_t value,
   return {bswap64(unshuffled_bcd) + zeros, unshuffled, len};
 #else
   auto result = to_bcd8(value);
-  return {result.bcd + zeros, result.len};
+  return {result.bcd + zeros, {}, result.len};
 #endif
 }
 

--- a/zmij.cc
+++ b/zmij.cc
@@ -1055,48 +1055,36 @@ ZMIJ_INLINE void write_digits(char* buffer, uint64_t digits,
   memmove(buffer, buffer + drop_leading_zero, sizeof(digits));
 }
 
-#if ZMIJ_USE_SSE4_1
+#if ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON
 ZMIJ_INLINE auto write_scientific_float_simd(
     char* buffer, const dec_digits<32>& dig, int last_digit_value,
     bool has_last_digit, bool extra_digit, uint64_t exp_data,
     const data& d) noexcept -> char* {
-  __m128i ascii = _mm_or_si128(dig.unshuffled,
-                               _mm_load_si128(m128ptr(&d.zeros)));
   uint32_t prefix = (uint32_t('.') << 8) + uint32_t('0') + last_digit_value;
   uint64_t hi_qword = (exp_data & 0xFFFFFFFFu) | (uint64_t(prefix) << 32);
-  __m128i src = _mm_insert_epi64(ascii, int64_t(hi_qword), 1);
   auto m = d.scientific_float_masks.get_entry(dig.num_digits, has_last_digit, extra_digit);
+
+#  if ZMIJ_USE_SSE4_1
+  __m128i ascii = _mm_or_si128(dig.unshuffled,
+                               _mm_load_si128(m128ptr(&d.zeros)));
+  __m128i src = _mm_insert_epi64(ascii, int64_t(hi_qword), 1);
   __m128i mask = _mm_load_si128(m128ptr(m.mask));
   __m128i out = _mm_shuffle_epi8(src, mask);
   _mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), out);
+#  else // ZMIJ_USE_NEON
+  uint8x16_t ascii = vorrq_u8(dig.unshuffled, vdupq_n_u8('0'));
+  uint8x16_t src = vreinterpretq_u8_u64(
+      vsetq_lane_u64(hi_qword, vreinterpretq_u64_u8(ascii), 1));
+
+  uint8x16_t mask = vld1q_u8(m.mask);
+  uint8x16_t out = vqtbl1q_u8(src, mask);
+  vst1q_u8(reinterpret_cast<uint8_t*>(buffer), out);
+#  endif
   return buffer + m.length;
 }
 
 // Dummy overload so write<double> instantiates cleanly. The runtime
 // guard `traits::num_bits == 32` in `write` folds this call away.
-ZMIJ_INLINE auto write_scientific_float_simd(
-    char*, const dec_digits<64>&, int, bool, bool, uint64_t,
-    const data&) noexcept -> char* {
-  return nullptr;
-}
-#elif ZMIJ_USE_NEON
-ZMIJ_INLINE auto write_scientific_float_simd(
-    char* buffer, const dec_digits<32>& dig, int last_digit_value,
-    bool has_last_digit, bool extra_digit, uint64_t exp_data,
-    const data& d) noexcept -> char* {
-  uint8x16_t ascii = vorrq_u8(dig.unshuffled, vdupq_n_u8('0'));
-  uint32_t prefix = (uint32_t('.') << 8) + uint32_t('0') + last_digit_value;
-  uint64_t hi_qword = (exp_data & 0xFFFFFFFFu) | (uint64_t(prefix) << 32);
-  uint8x16_t src = vreinterpretq_u8_u64(
-      vsetq_lane_u64(hi_qword, vreinterpretq_u64_u8(ascii), 1));
-
-  auto m = d.scientific_float_masks.get_entry(dig.num_digits, has_last_digit, extra_digit);
-  uint8x16_t mask = vld1q_u8(m.mask);
-  uint8x16_t out = vqtbl1q_u8(src, mask);
-  vst1q_u8(reinterpret_cast<uint8_t*>(buffer), out);
-  return buffer + m.length;
-}
-
 ZMIJ_INLINE auto write_scientific_float_simd(
     char*, const dec_digits<64>&, int, bool, bool, uint64_t,
     const data&) noexcept -> char* {

--- a/zmij.cc
+++ b/zmij.cc
@@ -1091,7 +1091,6 @@ ZMIJ_INLINE auto write_scientific_float_simd(
       vsetq_lane_u64(hi_qword, vreinterpretq_u64_u8(ascii), 1));
 
   auto m = d.scientific_float_masks.get_entry(dig.num_digits, has_last_digit, extra_digit);
-  int idx = (dig.num_digits - 1) * 4 + int(has_last_digit + 2 * extra_digit);
   uint8x16_t mask = vld1q_u8(m.mask);
   uint8x16_t out = vqtbl1q_u8(src, mask);
   vst1q_u8(reinterpret_cast<uint8_t*>(buffer), out);

--- a/zmij.cc
+++ b/zmij.cc
@@ -1083,7 +1083,7 @@ ZMIJ_INLINE auto write_scientific_float_simd(
 ZMIJ_INLINE auto write_scientific_float_simd(
     char* buffer, const dec_digits<32>& dig, int last_digit_value,
     bool has_last_digit, bool extra_digit, uint64_t exp_data,
-    const data&) noexcept -> char* {
+    const data& d) noexcept -> char* {
   uint8x16_t ascii = vorrq_u8(dig.unshuffled, vdupq_n_u8('0'));
   uint32_t prefix = (uint32_t('.') << 8) + uint32_t('0') + last_digit_value;
   uint64_t hi_qword = (exp_data & 0xFFFFFFFFu) | (uint64_t(prefix) << 32);

--- a/zmij.cc
+++ b/zmij.cc
@@ -540,25 +540,17 @@ struct exp_string_table {
   }
 };
 
-// Shuffle masks for branchless float scientific-notation output. A single
-// pshufb assembles "<d>.<rest><e±xx>" from a source register holding the
-// unshuffled (LSD-first) ASCII digits in bytes 0..7, the exp string
-// in bytes 8..11, the decimal point (byte 12 = '.'), and the last_digit
-// (ASCII, byte 13). The shuffle indices reverse the byte order while
-// inserting the decimal point and placing the exponent after the last
-// non-zero digit.
+// Shuffle masks to build strings in scientific form.
 //
-// In unshuffled form: for extra_digit, MSD lives at byte 7 (LSD at 0);
-// for the leading-zero-padded case (no extra_digit), MSD is at byte 6
-// and byte 7 holds the padding '0'.
+// We store the length in the last byte of the shuffle mask as it is always
+// past the end of the string.
 //
 // After benchmnarking, the fastest way of indexing appears to be a flat
-// array with index = (num_digits - 1) * 4 + has_last_digit * 2 + extra_digit.
+// array with the index calculation done explicitly in get_index.
 struct scientific_float_mask_table {
   static constexpr bool enable = (ZMIJ_USE_SSE4_1 || ZMIJ_USE_NEON) && exp_string_table::enable;
 
   alignas(16) unsigned char masks[enable ? 32 * 16 : 1] = {};
-  unsigned char lengths[enable ? 32 : 1] = {};
 
   constexpr auto get_index(int ndigits, int has_last, int has_extra_digit) const noexcept {
     return (ndigits - 1) * 4 + has_last * 2 + has_extra_digit;
@@ -571,7 +563,7 @@ struct scientific_float_mask_table {
 
   constexpr auto get_entry(int ndigits, bool has_last, bool has_extra_digit) const noexcept {
     auto idx = get_index(ndigits, has_last, has_extra_digit);
-    return entry{ &masks[idx * 16], lengths[idx] };
+    return entry{ &masks[idx * 16], masks[idx * 16 + 15] };
   }
 
   constexpr scientific_float_mask_table() {
@@ -606,7 +598,7 @@ struct scientific_float_mask_table {
           // Exp string follows the significand.
           for (unsigned char i = 0; i < 4; ++i)
             out[length++] = 8 + i;
-          lengths[idx] = length;
+          out[15] = length;
         }
       }
     }


### PR DESCRIPTION
This patch uses a table-driven approach to build the whole float string inside a SIMD register when outputting scientific notation. With clang 13.3 on Ubuntu this gains the advertised 30%, but that is because with this compiler, the pre-patch version is really slow.  Let me begin with the timings on my Tiger Lake:

clang 18.1.3:
| benchmark     |   base  |     test  |    Δ%   |      95% CI    |    p  verdict|
|--------|--------|--------|--------|--------|--------|
|zmij         | 18.18ns |   12.38ns | -31.9% | [-33.8,-30.0] |  2e-237  FASTER |
|dragonbox |    21.00ns |   20.51ns  | -2.3% | [ -4.3, -0.3] |   0.022  NOISE |

gcc 13.3.0:
| benchmark     |   base  |     test  |    Δ%   |      95% CI    |    p  verdict|
|--------|--------|--------|--------|--------|--------|
|zmij     |     13.67ns  |  13.15ns |  -3.8% | [ -5.9, -1.8] | 0.00019  FASTER |
|dragonbox  |   24.71ns |   24.54ns |  -0.7% | [ -2.5, +1.1] |    0.46  NOISE |

On Zen4 the gains are 5.9% and 7.7% respectively with more recent compilers, on M5 Mac it's on 0.7% which may not be enough to justify adding the tables (544 bytes).

So, what do the patch do? A float number is short enough to fit into an 16byte register together with the exponential string. We build a shuffle table that tells us where each digit from the byte-reversed BCD conversion, the decimal point and the exponent goes. The table can be seen in its entirety here https://godbolt.org/z/qbvP8TPMx Typical entries look like this:
```
ndigits 6
  has_extra_digit 0 has_last 0 mask [6, 13, 5, 4, 3, 2, 8, 9, 10, 11, 128, 128, 128, 128, 128, 128]
  has_extra_digit 0 has_last 1 mask [6, 13, 5, 4, 3, 2, 1, 0, 12, 8, 9, 10, 11, 128, 128, 128]
  has_extra_digit 1 has_last 0 mask [7, 13, 6, 5, 4, 3, 2, 8, 9, 10, 11, 128, 128, 128, 128, 128]
  has_extra_digit 1 has_last 1 mask [7, 13, 6, 5, 4, 3, 2, 1, 0, 12, 8, 9, 10, 11, 128, 128]
```
We arrange the input such that the converted digits are in bytes 0...7; 8, 9, 10, 11 are the exponent e+00, loaded from the other table, byte 13 is '.' and 12 is the extra digit.

The table is indexed by nDigits, has_extra_digit and has_last_digit, but makign it a flat array and calculating the offset directly turned out the fastest. Same goes for the order of indices which allows a two-step LEA evaluation, and only the second step (ndigits) doesn't proceed in parallel with the bcd. The order of the entries in the SIMD register is also the result of careful optimization to minimize the number of operations.

Finally, I tried evaluating the exponent BCD together with the significand to avoid the exp_table, but that added the insertion into the SIMD register on the top of the dependency chain whereas the table look up in the current version can be evaluated in parallel with the BCD conversion, which reduces the cost to zero. I investigated also prefixing the sign in the same way, but that would either double the size of the table or add another shuffle for no gain as long as the write-out buffer is not guaranteed to be aligned. With a gigantic table or a split shuffle lookup one could also do the fixed-formatting with the same code, but on a quick attempt I couldn't make it faster. It would need to tabulate a start position and where to put the decimal point as a function of the decimal exponent.

This partly addresses issue #133. Maybe someone who is more versed in NEON SIMD can also improve the timings that you gave in that PR :) 