### PR TITLE
Fix fixed benchmark

### DIFF
--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -161,6 +161,49 @@ static void run_to_chars_canada(benchmark::State& state,
           benchmark::Counter::kInvert);
 }
 
+// Doubles drawn uniformly from zmij's fixed-notation decimal-exponent range,
+// dec_exp in [-4, 15]: each decade is equally weighted, so the negative-
+// exponent side (which canada.json doesn't cover) gets ~25% of samples. Sized
+// to roughly match canada_numbers for comparable per-iteration cost.
+static const std::vector<double>& get_fixed_range_numbers() {
+  static const std::vector<double> v = [] {
+    constexpr size_t count =
+        sizeof(canada_numbers) / sizeof(canada_numbers[0]);
+    std::mt19937_64 rng(0);
+    std::uniform_int_distribution<int> exp_dist(-4, 15);
+    std::uniform_real_distribution<double> sig_dist(1.0, 10.0);
+    std::vector<double> out;
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      double sig = sig_dist(rng);
+      int e = exp_dist(rng);
+      out.push_back(sig * std::pow(10.0, e));
+    }
+    return out;
+  }();
+  return v;
+}
+
+static void run_to_chars_fixed_range(
+    benchmark::State& state, auto (*to_chars)(double, char*)->char*) {
+  const auto& nums = get_fixed_range_numbers();
+  char buffer[256];
+  for (auto _ : state) {
+    for (double x : nums) {
+      char* end = to_chars(x, buffer);
+      benchmark::DoNotOptimize(end);
+      benchmark::ClobberMemory();
+    }
+  }
+  state.counters["Throughput"] = benchmark::Counter(
+      static_cast<double>(nums.size()),
+      benchmark::Counter::kIsIterationInvariantRate);
+  state.counters["Time/double"] = benchmark::Counter(
+      static_cast<double>(nums.size()),
+      benchmark::Counter::kIsIterationInvariantRate |
+          benchmark::Counter::kInvert);
+}
+
 // Formats a counter value with 2 fractional digits, applying SI auto-scaling
 // so the mantissa always sits in [1, 1000) (or in [0.01, 1) for tiny values).
 static auto format_counter(double n) -> std::string {
@@ -233,6 +276,9 @@ static void register_all(bool per_digit) {
     if constexpr (std::is_same_v<T, double>) {
       auto canada_name = m.name + "/canada";
       benchmark::RegisterBenchmark(canada_name.c_str(), run_to_chars_canada,
+                                   m.to_chars);
+      auto fr_name = m.name + "/fixed_range";
+      benchmark::RegisterBenchmark(fr_name.c_str(), run_to_chars_fixed_range,
                                    m.to_chars);
     }
   }

--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -163,8 +163,9 @@ static void run_to_chars_canada(benchmark::State& state,
 
 // Doubles drawn uniformly from zmij's fixed-notation decimal-exponent range,
 // dec_exp in [-4, 15]: each decade is equally weighted, so the negative-
-// exponent side (which canada.json doesn't cover) gets ~25% of samples. Sized
-// to roughly match canada_numbers for comparable per-iteration cost.
+// exponent side (which canada.json doesn't cover) gets ~25% of samples. Signs
+// are randomized so the negative path is exercised too. Sized to roughly match
+// canada_numbers for comparable per-iteration cost.
 static const std::vector<double>& get_fixed_range_numbers() {
   static const std::vector<double> v = [] {
     constexpr size_t count =
@@ -172,12 +173,15 @@ static const std::vector<double>& get_fixed_range_numbers() {
     std::mt19937_64 rng(0);
     std::uniform_int_distribution<int> exp_dist(-4, 15);
     std::uniform_real_distribution<double> sig_dist(1.0, 10.0);
+    std::bernoulli_distribution sign_dist(0.5);
     std::vector<double> out;
     out.reserve(count);
     for (size_t i = 0; i < count; ++i) {
       double sig = sig_dist(rng);
       int e = exp_dist(rng);
-      out.push_back(sig * std::pow(10.0, e));
+      double val = sig * std::pow(10.0, e);
+      if (sign_dist(rng)) val = -val;
+      out.push_back(val);
     }
     return out;
   }();


### PR DESCRIPTION
Separates out the fixed benchmark added in #137 as requested in review (a long time ago, I had to recover from trying to use AI to find actual improvements and not hallucinated improvements).

Unlike the existing canada benchmark, this benchmark exercises the full exponential range of the fixed format output. The code path for negative exponents is different in that zeros are prefixed and the decimal point isn't inserted inside the digit string. This benchmark ensures that that variant is also exercised.

This uses an equidistribution of exponents and equidistributes the numbers in the range of each exponent. One change relative to the version in #137 is that I also added 50/50 randomness to the sign.